### PR TITLE
The "Where to find and Install" faq section is redundant

### DIFF
--- a/content/developer/eclipse/faq/EclipseFind.md
+++ b/content/developer/eclipse/faq/EclipseFind.md
@@ -1,8 +1,0 @@
-<!--
-title: "Where can my developers find and install Contrast for Eclipse?"
-description: "Where can my developers find and install Contrast for Eclipse?"
-tags: "Eclipse install"
--->
-
-## Where can my developers find and install Contrast for Eclipse?
-Eclipse users can install Contrast for Eclipse directly through the [Eclipse Marketplace](https://marketplace.eclipse.org/content/contrast-eclipse) by first searching for “Contrast.” 


### PR DESCRIPTION
The Eclipse section already has a page for installation which covers this topic