### PR TITLE
Pivotal Tile instructions update

### DIFF
--- a/content/user/agent/java/install/CloudFoundry.md
+++ b/content/user/agent/java/install/CloudFoundry.md
@@ -266,7 +266,7 @@ Once you define your plans, return to the Ops Manager dashboard and select the *
 
 This may take some time to deploy.
 
-## Step 2: Apps manager instructions
+### Step 2: Apps manager instructions
 Now that you've successfully deployed the service broker we can create services to bind the credentials to an application. Navigate to your Pivotal Apps Manager instance and go to the **Marketplace** tab, where a Contrast service broker option is present.
 
 <a href="assets/images/Pivotal_Marketplace.png" rel="lightbox" title="Contrast Security service broker in the marketplace"><img class="thumbnail" src="assets/images/Pivotal_Marketplace.png"/></a>

--- a/content/user/agent/java/install/CloudFoundry.md
+++ b/content/user/agent/java/install/CloudFoundry.md
@@ -5,7 +5,7 @@ tags: "java agent installation pivotal cloud foundry tile buildpack"
 -->
 Contrast offers a variety of Cloud Foundry integrations for your applications using the Contrast Java buildpack. The buildpack can be used on its own as a low level of integration by creating a user-provided service and binding the service to your application. The service broker is the next step towards closer integration with Contrast. The service broker allows you to define multiple service plans, and allows you to generate service instances in order to bind to applications.
 
-For Pivotal Cloud Foundry customers, we offer a Pivotal tile. This tile automates the BOSH deployment and configuration of Contrast Security service broker. 
+For Pivotal Cloud Foundry customers, we offer a Pivotal tile. This tile automates the BOSH deployment and configuration of Contrast Security service broker.
 
 ## Contrast Security Buildpack
 The Contrast Security agent buildpack allows an application to be configured to work with a bound Contrast service.
@@ -214,7 +214,7 @@ The Contrast tile can be found on our [Github site.](https://github.com/Contrast
 There are two ways to get the Pivotal tile.
 
 **Option 1 (download): **
-Within the repository root, there is a file called: contrast-security-service-broker-#.#.#.pivotal. Download this file.
+The Contrast Security Server Broker Tile for Pivotal Cloud Foundry can be downloded from the [Pivotal Network](https://network.pivotal.io/products/contrast-security-service-broker/).
 
 **Option 2 (manually build tile): **
 
@@ -302,4 +302,3 @@ Command line example:
 
 Pivotal Apps Manager example:
 <a href="assets/images/Pivotal_Environment_Variables.png" rel="lightbox" title="Environment variables through UI"><img class="thumbnail" src="assets/images/Pivotal_Environment_Variables.png"/></a>
-

--- a/content/user/agent/java/install/CloudFoundry.md
+++ b/content/user/agent/java/install/CloudFoundry.md
@@ -3,12 +3,12 @@ title: "Running Contrast on Cloud Foundry"
 description: "Agent configuration using the Contrast service broker, Contrast buildpack, and the Pivotal Tile"
 tags: "java agent installation pivotal cloud foundry tile buildpack"
 -->
-Contrast offers a variety of Cloud Foundry integrations for your applications using the Contrast Java buildpack. The buildpack can be used on its own as a low level of integration by creating a user-provided service and binding the service to your application. The service broker is the next step towards closer integration with Contrast. The service broker allows you to define multiple service plans, and allows you to generate service instances in order to bind to applications.
+Contrast offers a variety of Cloud Foundry integrations for your applications using the Contrast Java buildpack. You can use the buildpack on its own as a low level of integration by creating a user-provided service and binding the service to your application. The service broker is the next step towards closer integration with Contrast. The service broker allows you to define multiple service plans, and allows you to generate service instances in order to bind to applications.
 
-For Pivotal Cloud Foundry customers, we offer a Pivotal tile. This tile automates the BOSH deployment and configuration of Contrast Security service broker.
+For Pivotal Cloud Foundry (PCF) customers, Contrast offers a Pivotal tile. This tile automates the BOSH deployment and configuration of the Contrast service broker.
 
 ## Contrast Security Buildpack
-The Contrast Security agent buildpack allows an application to be configured to work with a bound Contrast service.
+The Contrast agent buildpack allows you to configure an application to work with a bound Contrast service.
 
 <table>
   <tr>
@@ -22,7 +22,7 @@ The Contrast Security agent buildpack allows an application to be configured to 
 Tags are printed to standard output by the buildpack detect script.
 
 ### User-provided service
-When binding Contrast using a user-provided service, you must give it a name or tag with `contrast-security` or `contrastsecurity` in it. The credential payload needs to contain the following entries:
+When binding Contrast using a user-provided service, you must give it a name or tag that includes `contrast-security` or `contrastsecurity`. The credential payload must also contain the following entries:
 
 
 | Name | Description
@@ -52,7 +52,7 @@ The Contrast service broker allows Cloud Foundry users to easily bind services t
 
 ### Prerequisites
 Any applications that you wish to use with the service broker should employ the Contrast buildpack in order to download and run the agent.
-The buildpack can be found [here](https://github.com/Contrast-Security-OSS/java-buildpack).
+You can find the buildpack [here](https://github.com/Contrast-Security-OSS/java-buildpack).
 Run the following command to use the buildpack:
 
 
@@ -60,7 +60,7 @@ Run the following command to use the buildpack:
 cf push YOUR_APP_NAME_GOES_HERE -b "https://github.com/Contrast-Security-OSS/java-buildpack"
 ```
 
-### How to set up (generic cf)
+### Set up (generic cf)
 
 Build service broker app:
 ```bash
@@ -74,7 +74,7 @@ Deploy service broker app:
     cf push contrast-security-service-broker -p /path/to/contrast-service-broker-<version>.jar
 ```
 
-The service broker should now appear in your Cloud Foundry console. The service broker doesn't offer any plans by default. Plans are configurable via the ```CONTRAST_SERVICE_PLANS``` environment variable. If using Pivotal, you can also use the Pivotal Ops Manager to set the environment variables. If using Bluemix, you can click on the application then select **Runtime** > **Environment Variables** to set the value. Please refer to the following example to set the value through the commandline:
+The service broker now appears in your Cloud Foundry console. The service broker doesn't offer any plans by default. Plans are configurable via the ```CONTRAST_SERVICE_PLANS``` environment variable. If using Pivotal, you can also use the Pivotal Ops Manager to set the environment variables. If using Bluemix, you can click on the application, select **Runtime** and then **Environment Variables** to set the value. Please refer to the following example to set the value through the commandline:
 
 ```
     cf set-env contrast-security-service-broker CONTRAST_SERVICE_PLANS
@@ -98,7 +98,9 @@ The service broker should now appear in your Cloud Foundry console. The service 
              } "
 ```
 
-If running the agent on Bluemix, you must use single quotes to set the ```CONTRAST_SERVICE_PLANS``` environment variable because Bluemix doesn't recognize double quotes. For example:
+If running the agent on Bluemix, you must use single quotes to set the ```CONTRAST_SERVICE_PLANS``` environment variable because Bluemix doesn't recognize double quotes. 
+
+Example:
 
 
 ```
@@ -143,7 +145,9 @@ Create a service broker instance. (At least one service plan must be defined.) Y
     <URL of your application>
 ```
 
-If running on Bluemix, add ```--space-scoped``` at the end of the command. For example:
+If running on Bluemix, add ```--space-scoped``` at the end of the command. 
+
+Example:
 
 ```bash
     cf create-service-broker contrast-security-service-broker USER_NAME PASSWORD
@@ -183,19 +187,17 @@ You should see the agent start up with your application and also see it in your 
 
 A service broker allows Cloud Foundry applications to bind to services and consume the services easily from the App Manager UI or the command line. The Contrast service broker enables you to use one or more Contrast accounts, and is deployed as a Java application on Cloud Foundry. The broker exposes the Contrast service on the Cloud Foundry marketplace, which allows users to directly create a service instance and bind it to their applications either from the Pivotal Apps Manager Console or the command line.
 
-Once deployed, this title will create one organization:
+Once deployed, this title creates one organization:
 
  * **contrast-security-service-broker-org**  - This organization is used for deploying the Contrast service broker application. Memory requirement = 512MB
 
-## Using Contrast with Java Applications on Pivotal Cloud Foundry
-The Contrast integration with Pivotal Cloud Foundry (PCF) allows you to easily deploy Contrast-monitored applications on the PCF platform.
+## Use Contrast with Java Applications on PCF 
+The Contrast integration with PCF allows you to easily deploy Contrast-monitored applications on the PCF platform. These instructions walk you through deploying a Java applicaton with a Contrast agent installed, and demonstrates the steps to get up and running with PCF and the Contrast Java buildpack.
 
-This article walks you through deploying a Java applicaton with a Contrast agent installed. It demonstrates the steps to get up and running with PCF and the Contrast Java buildpack.
+### Set up an application with the Contrast build pack
 
-### Setting up an application with the Contrast build pack
-
-To push an app that is using the Contrast buildpack to PCF, we will use the Cloud Foundry-provided spring music app as an example.
-The sample application can be cloned, built and pushed using the following commands:
+To push an app that is using the Contrast buildpack to PCF, use the Cloud Foundry-provided spring music app as an example.
+You can clone, build and push the sample application using the following commands:
 
 ```bash
     git clone https://github.com/cloudfoundry-samples/spring-music.git
@@ -205,25 +207,24 @@ The sample application can be cloned, built and pushed using the following comma
 ```
 
 
-## Adding the Contrast Service Broker Tile
+## Add The Contrast Service Broker Tile
 
 ### Step 1: Ops manager configuration
-The first step of integrating Contrast with your Pivotal Cloud Foundry is to install the Contrast tile.
-The Contrast tile can be found on our [Github site.](https://github.com/Contrast-Security-OSS/contrast-pivotal-tile)
+The first step of integrating Contrast with your PCF is installing the Contrast tile. You can find the Contrast tile on our [Github site.](https://github.com/Contrast-Security-OSS/contrast-pivotal-tile)
 
 There are two ways to get the Pivotal tile.
 
-**Option 1 (download): **
-The Contrast Security Server Broker Tile for Pivotal Cloud Foundry can be downloded from the [Pivotal Network](https://network.pivotal.io/products/contrast-security-service-broker/).
+**Option 1 (Download): **
+Download the Contrast server broker tile for PCF from the [Pivotal Network](https://network.pivotal.io/products/contrast-security-service-broker/).
 
-**Option 2 (manually build tile): **
+**Option 2 (Manually build tile): **
 
-    You first need to install:
+    Begin with the installation:
 
     1. [Maven](http://maven.apache.org/install.html)
     2. [Tile Generator CLI](https://github.com/cf-platform-eng/tile-generator)
 
-    Once you have installed Maven and the Tile Generator CLI, clone the Contrast service broker and build it.
+    Once you've installed Maven and the Tile Generator CLI, clone the Contrast service broker and build it.
 
         ```bash
             git clone https://github.com/Contrast-Security-OSS/contrast-service-broker.git
@@ -237,17 +238,15 @@ The Contrast Security Server Broker Tile for Pivotal Cloud Foundry can be downlo
 
         This will generate a contrast-security-service-broker.#.#.#.pivotal file within the product directory.
 
-Once you have the file stored locally, navigate to your Pivotal Ops Manager instance.
+Once you've stored the file locally, navigate to your Pivotal Ops Manager instance. In the Ops Manager, click on the **Import a Product** button and select the *contrast-security-service-broker-#.#.#.pivotal* tile that you downloaded or created in the previous step.
 
-In the Ops Manager, click on the **Import a Product** button and select the **contrast-security-service-broker-#.#.#.pivotal** tile that was downloaded or created in the previous step.
+The tile requires some configuration before we can deploy it. 
 
-The tile requires some configuration before we can deploy it.
-The service broker does **not** offer any service plans by default and requires that at least one service plan be configured before it will allow the tile to be deployed.
-To add a service plan, go to the **Service Plans** tab within the Contrast tile and click the **Add** button.
+The service broker does **not** offer any service plans by default and requires that at least one service plan be configured before it will allow the tile to be deployed. To add a service plan, go to the **Service Plans** tab within the Contrast tile and click the **Add** button.
 
 <a href="assets/images/Pivotal_Service_Plan.png" rel="lightbox" title="Adding a service plan"><img class="thumbnail" src="assets/images/Pivotal_Service_Plan.png"/></a>
 
-You will now be presented with six form fields.
+You can now see six form fields.
 
 | Parameter                    | Description                                             |
 |------------------------------|---------------------------------------------------------|
@@ -260,38 +259,31 @@ You will now be presented with six form fields.
 
 ---
 
-Once you have finished defining a plan, click the **Save** button.
+Once you're finished defining a plan, click the **Save** button. If you want some apps to belong to different organizations, define any other plans you may need.
 
-Define any other plans you may need if you want some apps to belong to different organizations.
-
-Once you have defined your plans, return to the Ops Manager dashboard and select the **Apply Changes** button.
+Once you define your plans, return to the Ops Manager dashboard and select the **Apply Changes** button.
 <a href="assets/images/Pivotal_Apply_Changes.png" rel="lightbox" title="Apply changes"><img class="thumbnail" src="assets/images/Pivotal_Apply_Changes.png"/></a>
 
 This may take some time to deploy.
 
 ## Step 2: Apps manager instructions
-Now that we have successfully deployed the service broker we can create services to bind the credentials to an application.
-Navigate to your Pivotal Apps Manager instance.
-
-Go to the **Marketplace** tab.
-A Contrast service broker option should now be present.
+Now that you've successfully deployed the service broker we can create services to bind the credentials to an application. Navigate to your Pivotal Apps Manager instance and go to the **Marketplace** tab, where a Contrast service broker option is present.
 
 <a href="assets/images/Pivotal_Marketplace.png" rel="lightbox" title="Contrast Security service broker in the marketplace"><img class="thumbnail" src="assets/images/Pivotal_Marketplace.png"/></a>
 
-Click the **Contrast service broker** option to see the available plans. These plans are the same that were entered in the Ops Manager.
+Click the **Contrast service broker** option to see the available plans. These are the same plans that you entered in the Ops Manager.
 Select the plan you want to bind to an application by clicking the **Select this Plan** button.
 
 <a href="assets/images/Pivotal_Select_Plan.png" rel="lightbox" title="Selecting a plan to bind"><img class="thumbnail" src="assets/images/Pivotal_Select_Plan.png"/></a>
 
-On the next screen, specify an instance name of the plan. (This will not effect the service broker, so you may name it anything you wish.)
+On the next screen, specify an instance name of the plan. (This doesn't effect the service broker, so you can name it anything you like.)
 Under the **Bind to App** dropdown, select the application to which you want to bind this service.
 <a href="assets/images/Pivotal_Bind_App.png" rel="lightbox" title="Binding service instance to application"><img class="thumbnail" src="assets/images/Pivotal_Bind_App.png"/></a>
 
+Now that you bound our service instance to an application, you can restage the application. The latest Java agent will be retrieved from your Teamserver and run on your application.
 
-Now that we have bound our service instance to an application, we can restage the application and the latest Java agent will be retrieved from your Teamserver and ran on your application.
-
-### Setting environment variables for Contrast
-If you wish to override Java agent properties, such as the applications name, you can set these through the use of environment variables either through the Pivotal UI or the cf command line.
+### Set environment variables for Contrast
+If you want to override Java agent properties, such as the application name, you can use environment variables through the Pivotal UI or the Cloud Foundry command line.
 
 Command line example:
 


### PR DESCRIPTION
Since we first published this article our tile has now made it onto the official Pivotal Network site.  This is just updating the instructions to reflect that the tile can be found there rather than in the github repository