### PR TITLE
CONTRAST-14762. Fix versioning in docs for bluemix

### DIFF
--- a/content/installation/node/NodeInstallBluemix.md
+++ b/content/installation/node/NodeInstallBluemix.md
@@ -8,7 +8,7 @@ Use the Contrast agent to instrument Node applications deployed on IBM Bluemix. 
 
 ## Download
 
-* Download the Node.js agent from Contrast. The latest version is **nodecontrast-0.9.0.tgz**.
+* Download the Node.js agent from Contrast. 
 
 * Download the *contrast.json* file from Contrast.
 
@@ -38,7 +38,7 @@ Use the Contrast agent to instrument Node applications deployed on IBM Bluemix. 
 Now the scripts section of the package.json should look like the following:
 "scripts": {
 "bluemix-with-contrast": "npm install /home/vcap/app/contrast/node-contrast-
-0.9.0.tgz && node-contrast -c /home/vcap/app/contrast/contrast.json index.js",
+x.y.z.tgz && node-contrast -c /home/vcap/app/contrast/contrast.json index.js",
 "start":"npm run bluemix-with-contrast”
 },
 ```

--- a/content/installation/node/NodeInstallBluemix.md
+++ b/content/installation/node/NodeInstallBluemix.md
@@ -26,7 +26,7 @@ Use the Contrast agent to instrument Node applications deployed on IBM Bluemix. 
 
 ```
 "bluemix-with-contrast": "npm install /home/vcap/app/contrast/node-contrast-
-0.9.0.tgz && node-contrast -c /home/vcap/app/contrast/contrast.json index.js",
+x.y.z.tgz && node-contrast -c /home/vcap/app/contrast/contrast.json index.js",
 ```
 
 ## Run the Agent


### PR DESCRIPTION
In general, I think that hardcoded version numbers should be avoid in general docs like this, because versions are subject to change so frequently.