### PR TITLE
Update Configure-http-proxy.md

### DIFF
--- a/content/installation/setup/auth/Configure-http-proxy.md
+++ b/content/installation/setup/auth/Configure-http-proxy.md
@@ -7,9 +7,9 @@ tags: "installation setup EOP system settings connect https proxy header"
 
 Contrast supports x509 client certificate authentication through a trusted proxy, which authenticates the user and then sends the user's username to Contrast in a HTTP header. To enable trusted HTTPS proxy authentication: 
 
-* Update the property file by changing the `authentication.mode` in *~/path_to_contrast_installation/conf/auth.properties* to `http_header`. 
+* Update the property file by changing the `authentication.mode` in *~/path_to_contrast_installation/data/conf/auth.properties* to `http_header`. 
 * By default, the HTTP header name is `Contrast-Authentication`. This is configurable in the *auth.properties* file, if you update the value of `auth.http.header.field.name`.
 
 * After restarting Contrast, each request must include the HTTP header `Contrast-Authentication: username` to login. 
 
-> **Note:** Trusted HTTPS proxy authentication should only be used if all Contrast nodes are accessible exclusively through a trusted proxy. No nodes should be accessible directly.
+> **Note:** Trusted HTTPS proxy authentication should only be used if all Contrast nodes are accessible exclusively through a trusted proxy. No nodes should be accessible directly, otherwise an attacker could impersonate any authorized user.


### PR DESCRIPTION
The auth.properties file is in data/conf, not just conf under wherever Contrast is installed.  I also added a clarification to the risk description in the note.