### PR TITLE
Corrected example to list all URLs in exclusion

### DIFF
--- a/content/admin/policy_mgmt/Exclusions.md
+++ b/content/admin/policy_mgmt/Exclusions.md
@@ -30,14 +30,14 @@ In conjunction with the input type, you must choose how to apply URLs:
 
 * **These URLs** (allows regex): Specify a set of URLs to which to apply the exclusion. 
 
->**Note:** Wildcard ```.*``` is an acceptable substitute for listing all URLs.
+>**Note:** Slash followed by wildcard ```/.*``` is an acceptable substitute for listing all URLs.
 
 
 ### URL
 
 This type of exclusion allows you to focus on a list of specific URLs to be ignored using **These URLs**. In this field, you can list the specific URLs to exclude, resulting in any findings from these URLs being suppressed. 
 
->**Note:** Wildcard ```.*``` is an acceptable substitute for listing all URLs.
+>**Note:** Slash followed by wildcard ```/.*``` is an acceptable substitute for listing all URLs.
 
 
 ### Code


### PR DESCRIPTION
Added a slash before the wildcard in the example to list all URLs. The current .* example isn't valid and you need to use /.* to match against all URLs.