### PR TITLE
Update the "Policy Management" section

### DIFF
--- a/content/admin/policy_mgmt/SecurityControls.md
+++ b/content/admin/policy_mgmt/SecurityControls.md
@@ -28,7 +28,7 @@ To create a new security control, click the **Add Security Control** button.
 
 <a href="assets/images/Security-control-add.png" rel="lightbox" title="Add a security control"><img class="thumbnail" src="assets/images/Security-control-add.png"/></a>
 
-After choosing a Name, Type and Language, specify the API and choose the vulnerability rules to which you'd like to apply the control. You can choose **All**, or select one or more individual vulnerabilities.
+After choosing a Name, Type and Language, specify the API and choose the vulnerability rules to which you'd like to apply the control. You can choose **All**, or select one or more individual vulnerabilities. It is important to note that Security Controls are intended to target only java.lang.String parameters (not boolean, int, long, short double, float, etc).
 
 >**Note:** Servers may require restart. Contrast provides a list of servers affected by your selection.
 


### PR DESCRIPTION
There are often users who are not aware that these security controls are intended to target java.lang.String and not any other primitives (like boolean, int, long, short double, float, etc.) It would be great if there was a note added to this section to emphasize the intended use for targeting only java.lang.String so that users are aware when creating the control.