### PR TITLE
Update JIRA.md

### DIFF
--- a/content/admin/org_settings/integrations/JIRA.md
+++ b/content/admin/org_settings/integrations/JIRA.md
@@ -40,7 +40,7 @@ Use two-way integration to automatically update the status of a linked vulnerabi
 
 <a href="assets/images/Two-way-jira-integration.png" rel="lightbox" title="Enable two-way integration"><img class="thumbnail" src="assets/images/Two-way-jira-integration.png"/></a>
 
-In the JIRA configuration page, begin setup by checking the box to **Enable two-way integration**. This generates a URL that appears below the checkbox, which your JIRA administrator must use to register a webhook in JIRA. Clicking the link opens a new tab that takes you to [instructions for registering webhooks](https://developer.atlassian.com/jiradev/jira-apis/webhooks#Webhooks-rest).
+In the JIRA configuration page, begin setup by checking the box to **Enable two-way integration**. This generates a URL that appears below the checkbox, which your JIRA administrator must use to register a webhook in JIRA. Clicking the link opens a new tab that takes you to [instructions for registering webhooks](https://developer.atlassian.com/jiradev/jira-apis/webhooks#Webhooks-rest). Place a check for the **updated** event type under **Issue** column for **Issue related events** in the webhook configuration.
 
 > **Note:** When you delete a configuration with two-way integration enabled, you must delete the webhook configuration from your JIRA administrator console to completely remove the integration.
 


### PR DESCRIPTION
Add an instruction for the 2-way JIRA integration to set the correct event type to fire on.  I set up a vanilla JIRA instance and the webhook didn't fire without this option selected.