### PR TITLE
Fix contrast.appname

### DIFF
--- a/content/installation/java/installation/DesktopStandaloneApp.md
+++ b/content/installation/java/installation/DesktopStandaloneApp.md
@@ -4,9 +4,9 @@ description: "Instructions for running Java agent on desktop or standalone app"
 tags: "java agent desktop installation"
 -->
 
-The process is pretty much the same, but you have to also pass a name in the ```contrast.appname``` system property under which to collect vulnerabilities.
+The process is pretty much the same, but you have to also pass a name in the ```contrast.standalone.appname``` system property under which to collect vulnerabilities.
 
 ```
--Dcontrast.appname=AcmeDesktopApp -javaagent:<path>/contrast.jar
+-Dcontrast.standalone.appname=AcmeDesktopApp -javaagent:<path>/contrast.jar
 ```
 

--- a/content/installation/java/installation/DropWizard.md
+++ b/content/installation/java/installation/DropWizard.md
@@ -9,7 +9,7 @@ tags: "java agent installation dropwizard"
 Here's an example of how to run the Java Agent with your standalone/fatjar Dropwizard application:
 
 ````
-java -javaagent:/path/to/contrast.jar -Dcontrast.appname="AppNameToReportUnder" -jar /path/to/your/app.jar server /path/to/your/appconfig.yml
+java -javaagent:/path/to/contrast.jar -Dcontrast.standalone.appname="AppNameToReportUnder" -jar /path/to/your/app.jar server /path/to/your/appconfig.yml
 ````
 
 The Java Agent will not be able to accurately count library usage if your project was configured to shade dependencies into your application's jar. Instead, the Java Agent will report a list of jars based on the information gathered from the pom.properties files provided with the included libraries.

--- a/content/installation/java/installation/Karaf.md
+++ b/content/installation/java/installation/Karaf.md
@@ -21,10 +21,10 @@ Navigate to your application, and allow an extra minute for it to start up.
 
 Many Karaf users will probably want to use two extra system properties when running Contrast:
  * *contrast.classpath.libs*, which tells Contrast to use the standard classpath libraries instead of libraries found in */WEB-INF/lib*
- * *contrast.appname*, which allows you to name your application
+ * *contrast.override.appname*, which allows you to name your application
  
 Adding these flags will result in an export that looks more like the following:
 
 ```
-$ export KARAF_OPTS="-Dcontrast.appname=MyKarafApp -Dcontrast.classpath.libs=true -javaagent:/path/to/contrast.jar"
+$ export KARAF_OPTS="-Dcontrast.override.appname=MyKarafApp -Dcontrast.classpath.libs=true -javaagent:/path/to/contrast.jar"
 ```

--- a/content/installation/java/installation/Vertx.md
+++ b/content/installation/java/installation/Vertx.md
@@ -67,11 +67,11 @@ Once this is configured, launch the web application via the command **vertx run*
 vertx run /PATH/TO/YOUR/src/MainVerticle.java
 ```
 
-The Vert.x application is unlikely to have a ***/WEB-INF/web.xml*** file, from which the Contrast Java Agent can identify the application name. If this is the case, please define the application name via ```-Dcontrast.appname=AppName``` property when launching the Vert.x application with Contrast enabled. For example:
+The Vert.x application is unlikely to have a ***/WEB-INF/web.xml*** file, from which the Contrast Java Agent can identify the application name. If this is the case, please define the application name via ```-Dcontrast.override.appname=AppName``` property when launching the Vert.x application with Contrast enabled. For example:
 
 ```bash
 java -javaagent:/PATH/TO/YOUR/contrast.jar 
--Dcontrast.appname="<Name_to_show_on_TeamServer>" <other options> 
+-Dcontrast.override.appname="<Name_to_show_on_TeamServer>" <other options> 
 -jar /PATH/TO/YOUR/application.jar
 ```
  


### PR DESCRIPTION
The -Dcontrast.appname property is deprecated, we should change them to -Dcontrast.standalone.appname or -Dcontrast.override.appname, whichever is correct for the situation. I guessed which property would work but someone with more experience with these frameworks should verify my suggestions are correct. 