### PR TITLE
Update intructions to reference yaml instead of json.

### DIFF
--- a/content/installation/node/NodeInstallBluemix.md
+++ b/content/installation/node/NodeInstallBluemix.md
@@ -10,11 +10,11 @@ Use the Contrast agent to instrument Node applications deployed on IBM Bluemix. 
 
 * Download the Node.js agent from Contrast. 
 
-* Download the *contrast.json* file from Contrast.
+* Download the *contrast_security.yaml* file from Contrast.
 
 ## Setup
 
-* In the *contrast.json* file, you can configure the name of the server to which this application will report. (Contrast recommends that you complete this step to avoid creating duplicate servers in the application.) To configure the server name as "BluemixNodeServer" in Contrast, add `server.name: BluemixNodeServer`. 
+* In the *contrast_security.yaml* file, you can configure the name of the server to which this application will report. (Contrast recommends that you complete this step to avoid creating duplicate servers in the application.) To configure the server name as "BluemixNodeServer" in Contrast, add `server.name: BluemixNodeServer`. 
 
 > **Example:**
     ```yaml


### PR DESCRIPTION
Updated instructions for bluemix to reference yaml file instead of json. Saw this on a call today.