### PR TITLE
Contrast 23556 integrated service

### DIFF
--- a/content/installation/ruby/RubyConfig.md
+++ b/content/installation/ruby/RubyConfig.md
@@ -17,9 +17,9 @@ The configuration file is called *contrast_security.yaml* wherever it's located.
 
 ## Service Configuration
 
-The ruby agent launches an executable on startup that also needs access to the configuration files. Since the service is generally launched by the ruby agent process it has access to the same configuration file as the agent. However if the service is started independently it will attempt to use the same load path described above for its configuration file. 
+The Ruby agent launches an executable on startup that also needs access to the configuration files. Since the service is generally launched by the Ruby agent process, it has access to the same configuration file as the agent. However, if the service is started independently, it will attempt to use the same load path described above for its configuration file. 
 
-In other words, the service can share the application's configuration file if (as is usually the case) the service's working directory is also the base directory of the Rails application. Both the agent and the service use the *./config/contrast_security.yaml* path. 
+In other words, the service can share the application's configuration file, if (as is usually the case) the service's working directory is also the base directory of the Rails application. Both the agent and the service use the *./config/contrast_security.yaml* path. 
 
 ### Tagging
 
@@ -42,14 +42,14 @@ For Trace tags, update the configuration of the agent. If there isn’t one, add
 
 The configuration YAML consists of four sections. The agent and service may share a common configuration file, but only some options and sections are applicable to each process.
 
-* `contrast`: Options for locating and communicating with the Contrast interface Dashboard
+* `contrast`: Options for locating and communicating with the Contrast UI Dashboard
   * `url`: URL to connect to the Contrast application
-  * `api_key`: Organization's API key
-  * `service_key`:  Service Key of Organization
-  * `user_name`: Username of user in TeamServer
+  * `api_key`: API key of the organization
+  * `service_key`:  Service Key of the organization
+  * `user_name`: Username of user in the Contrast application
 * `agent`: Options for communicating between the agent and the service
   * `logger`:
-    * `path`: Filename of the Contrast Security log file for the agent (*contrast_agent.log*)
+    * `path`: Filename of the Contrast log file for the agent (*contrast_agent.log*)
     * `level`: Level of logging details (DEBUG, INFO, WARN, ERROR)
     * `progname`: Name used to identify the process within the log file (Contrast Agent)
   * `cef_logger`:
@@ -68,14 +68,14 @@ The configuration YAML consists of four sections. The agent and service may shar
   * `group`: Group name for this application
 * `server`: Information about the server on which the web application is hosted
   * `name`: Name under which to register the server in the Contrast application 
-  * `environment`: Environment as which applications on this server should register themselves on the Contrast application (Development); this does not affect servers that already exist in Contrast
+  * `environment`: Environment as which applications on this server should register themselves on the Contrast application (Development); this does not affect servers that already exist in Contrast.
   * `tags`: Comma-delimited list of tags for this server
 * `inventory`
   * `tags`: Comma-delimited list of tags for this library
 
-## Ruby Specific Configuration Options
+## Ruby-Specific Configuration Options
 
-The following configuration options allow for fine-tuning the ruby agent.
+The following configuration options allow you to fine-tune the Ruby agent.
 
-* `ruby`: Options specific to the ruby agent
-  * `analyze_inventory_async`: If set to 'true', this wraps the initial inventory message in a thread which may speed up the response time on the first request after startup. 
+* `ruby`: Options specific to the Ruby agent
+  * `analyze_inventory_async`: If set to `true`, this wraps the initial inventory message in a thread which may speed up the response time on the first request after startup. 

--- a/content/installation/ruby/RubyConfig.md
+++ b/content/installation/ruby/RubyConfig.md
@@ -12,15 +12,18 @@ The configuration file is called *contrast_security.yaml* wherever it's located.
 
 1. The current working directory (e.g., *./contrast_security.yaml*)
 2. A subdirectory called *config*, which is the default for Ruby on Rails applications (e.g., *./config/contrast_security.yaml*)
+3. Within the server's *etc/contrast* directory (e.g. */etc/contrast/contrast_security.yaml*)
 3. Within the server's *etc* directory (e.g., */etc/contrast_security.yaml*)
 
-## Ruby Service and Ruby Agent
+## Service Configuration
 
-Configuration files for Ruby on Rails applications are usually stored in the *./config* directory of the application. The Ruby service can share the application's configuration file if the service's working directory is also the base directory of the Rails application. Both the agent and the service use the *./config/contrast_security.yaml* path; however, this isn't required. The Ruby service can run from any other directory on the server - in which case, it should have its own copy of the configuration file.  
+The ruby agent launches an executable on startup that also needs access to the configuration files. Since the service is generally launched by the ruby agent process it has access to the same configuration file as the agent. However if the service is started independently it will attempt to use the same load path described above for its configuration file. 
+
+In other words, the service can share the application's configuration file if (as is usually the case) the service's working directory is also the base directory of the Rails application. Both the agent and the service use the *./config/contrast_security.yaml* path. 
 
 ### Tagging
 
-The Ruby agent and service support the full array for tagging messages to the Contrast server. To apply these tags, you must update your configuration files in either the agent or the service. Tags in the configuration are comma-separated alphanumeric strings. Each tag will be attached to a corresponding message from the agent or service, depending which field is set.
+The Ruby agent supports the full array of tagging messages to the Contrast server. To apply these tags, you must update your configuration files. Tags in the configuration are comma-separated alphanumeric strings. Each tag will be attached to a corresponding message from the agent or service, depending which field is set.
 
 For **server** tags, update the configuration of the service. If there isn’t one, add a top-level `server` field to the *contrast_security.yaml* file. Under that heading, add a `tags` field, which you may set to any comma-separated alphanumeric string.
 
@@ -69,3 +72,10 @@ The configuration YAML consists of four sections. The agent and service may shar
   * `tags`: Comma-delimited list of tags for this server
 * `inventory`
   * `tags`: Comma-delimited list of tags for this library
+
+## Ruby Specific Configuration Options
+
+The following configuration options allow for fine-tuning the ruby agent.
+
+* `ruby`: Options specific to the ruby agent
+  * `analyze_inventory_async`: If set to 'true', this wraps the initial inventory message in a thread which may speed up the response time on the first request after startup. 

--- a/content/installation/ruby/RubyInstall.md
+++ b/content/installation/ruby/RubyInstall.md
@@ -10,18 +10,23 @@ To install the Contrast agent into your Ruby application, you must complete the 
 
 1. Add the <i>contrast-agent-*.gem</i> to the application Gemfile. (This is outlined in the <b>Setup</b> section below.) 
 2. Add the *contrast_security.yaml* file to the application's *config* directory. (This is outlined in the **Configuration** section below.)
-3. Run the `contrast-service-*.gem` as a standalone service on the same server as the application. (This is outlined in the section below to **Run the Service**.)
 
 ## Setup
 
-The <i>contrast-agent-*.gem</i> is a standard Ruby library that you can add to the application Gemfile. You can complete setup using Contrast as a Gem Source or by installing Contrast manually.
+The <i>contrast-agent-*.gem</i> is a standard Ruby library that you can add to the application Gemfile. You can complete setup using Contrast UI as a Gem Source or by installing the gem manually. 
+
+Manual installation is done using the `gem` command.
+
+``` ruby
+gem install path/to/contrast-agent-2.x.x.gem
+```
 
 ### Contrast as a Gem Source
 
 To use Contrast as a Gem Source, add this line to your application's Gemfile:
 
 ``` ruby
-gem 'contrast-agent'
+gem 'contrast-agent', '~> 2.0'
 ```
 
 Add this line to the top of your application's Gemfile:
@@ -32,13 +37,17 @@ source 'https://app.contrastsecurity.com/Contrast/api/repo/rvm'
 
 After editing the Gemfile, you must bundle the *contrast-agent* gem by adding authorization to your Bundler:
 
-> **Note:** Make sure that your username is CGI escaped.
+> **Note:** Make sure that your username is CGI escaped. For example, `fname.lname@example.com` becomes `fname.lname%40example.com`.
 
 ``` bash
 bundle config https://app.contrastsecurity.com/Contrast/api/repo/rvm ${username}:${service_key}
 ```
 
 Finally, run an update:
+
+``` bash
+bundle install
+```
 
 ``` bash
 bundle update
@@ -76,37 +85,39 @@ bundle install ./path/to/contrast-agent-*.gem
 Download a standard configuration file from the Contrast application. You must place the file in the web application's *config* directory, and define the following fields, at a minimum:
 
 ``` yaml
+contrast:
+  url: 
+  api_key:
+  service_key:
+  user_name:
 agent:
   service:
     host: 
     port:
-```
-
-## Run the Service
-
-The `contrast-service-*.gem` is an executable that you must run on the same server as the web application. Begin by downloading the `contrast-service-*.gem` from the Contrast application. It must be the same version as the <i>contrast-agent-*.gem</i>.
-
-The service, like the agent, reads its configuration from one of the following locations in the following order: 
-
-1. The current working directory
-2. The YAML file in the *config* subdirectory (e.g. *config/contrast_security.yaml*), if the working directory of the service is the web application's root directory
-3. The system's */etc/contrast_security.yaml* file
-
-Define the following sections, at minimum, in the configuration file:
-
-```yaml
-contrast:
-  url:
-  user_name:
-  api_key:
-  service_key:
-agent:
-  service:
-    host: 
-    port: 
     logger:
       path: 
       level:
 ```
 
+For Sinatra application the config file can be placed directly in the working directory. For sharing a config file across multiple applications the file may be placed in `/etc/contrast/contrast_security.yaml`.
+
+## Run the Service
+
+On application startup, the Contrast agent gem starts a service in a separate process. This process is responsible for aggregating messages from the agent, sending attack information to Contrast UI and receiving updates to settings from the UI. The agent is packaged with 64-bit Mac, Linux and Windows services.  Because the service is launched by the agent it has access to the same config file that the agent used. If the service process is stopped, the agent will attempt to restart it. In the unlikely event that the restart process fails, after 5 attempts the agent will cease trying to restart the service and will not send findings to the Contrast UI. However, it will continue to protect the application using the last settings it received. 
+
+The service status can be accessed using take tasks:
+
+* `rake contrast:service:status`: returns `online` or `offline`
+* `rake contrast:service:start`: attempts to start the service using the configuration for the local contrast agent
+* `rake contrast:service:stop`: attempts to stop the service. Note that if the agent receives additional requests it will attempt to restart the service on its own.
+
+## Troubleshooting 
+
+### Multitple Agents
+
+*Ensure that the service host and port values are consistent.* Because the agent attempts to start the service on application startup, if there are multiple applications protected by the contrast agent, the first one to start will launch the service. This is not a problem since the service is designed to handle communication with multiple agents, however if the `agent.service.host` and `agent.service.port` configuration values don't match then the additional agent will be unable to communicate with the previously started service.
+
+### Delay on First Request
+
+*Inventory and coverage metrics are gathered on first request.* The initial message to the Contrast UI containes information about the routes and Gems used by the application for inventory analysis. This is a relatively heavyweight process and may add a few seconds to the response time for the initial HTTP request to the application. Under some application servers (e.g. Puma) adding the `ruby.analyze_inventory_async: true` configuration can reduce this delay.
 

--- a/content/installation/ruby/RubyInstall.md
+++ b/content/installation/ruby/RubyInstall.md
@@ -15,7 +15,7 @@ To install the Contrast agent into your Ruby application, you must complete the 
 
 The <i>contrast-agent-*.gem</i> is a standard Ruby library that you can add to the application Gemfile. You can complete setup using Contrast UI as a Gem Source or by installing the gem manually. 
 
-Manual installation is done using the `gem` command.
+For manual installation, use the `gem` command:
 
 ``` ruby
 gem install path/to/contrast-agent-2.x.x.gem
@@ -23,13 +23,13 @@ gem install path/to/contrast-agent-2.x.x.gem
 
 ### Contrast as a Gem Source
 
-To use Contrast as a Gem Source, add this line to your application's Gemfile:
+To use Contrast as a Gem Source, add the following line to your application's Gemfile:
 
 ``` ruby
 gem 'contrast-agent', '~> 2.0'
 ```
 
-Add this line to the top of your application's Gemfile:
+Add the following line to the top of your application's Gemfile:
 
 ``` ruby
 source 'https://app.contrastsecurity.com/Contrast/api/repo/rvm'
@@ -53,7 +53,7 @@ bundle install
 bundle update
 ```
 
-If you're using the Sinatra framework, you must configure your application to use the Contrast agent. A simple application configured to work with the Contrast agent looks like the following:
+If you're using the Sinatra framework, you must configure your application to use the Contrast agent. A simple application configured to work with the Contrast agent looks like the following example:
 
 ``` ruby
 require 'sinatra'
@@ -99,25 +99,25 @@ agent:
       level:
 ```
 
-For Sinatra application the config file can be placed directly in the working directory. For sharing a config file across multiple applications the file may be placed in `/etc/contrast/contrast_security.yaml`.
+For Sinatra applications, you may directly place the configuration file in the working directory. For sharing a configuration file across multiple applications, you may place the file in */etc/contrast/contrast_security.yaml*.
 
 ## Run the Service
 
-On application startup, the Contrast agent gem starts a service in a separate process. This process is responsible for aggregating messages from the agent, sending attack information to Contrast UI and receiving updates to settings from the UI. The agent is packaged with 64-bit Mac, Linux and Windows services.  Because the service is launched by the agent it has access to the same config file that the agent used. If the service process is stopped, the agent will attempt to restart it. In the unlikely event that the restart process fails, after 5 attempts the agent will cease trying to restart the service and will not send findings to the Contrast UI. However, it will continue to protect the application using the last settings it received. 
+On application startup, the Contrast agent gem starts a service in a separate process. This process is responsible for aggregating messages from the agent, sending attack information to Contrast UI and receiving updates to settings from the UI. The agent is packaged with 64-bit Mac, Linux and Windows services. Because the service is launched by the agent, it has access to the same configuration file that the agent used. If the service process is stopped, the agent will attempt to restart it. In the unlikely event that the restart process fails, the agent will cease trying to restart the service after five attempts, and won't send findings to the Contrast UI. However, the agent will continue to protect the application using the last settings it received. 
 
-The service status can be accessed using take tasks:
+You can access the service status using take tasks:
 
-* `rake contrast:service:status`: returns `online` or `offline`
-* `rake contrast:service:start`: attempts to start the service using the configuration for the local contrast agent
-* `rake contrast:service:stop`: attempts to stop the service. Note that if the agent receives additional requests it will attempt to restart the service on its own.
+* `rake contrast:service:status`: Returns `online` or `offline`.
+* `rake contrast:service:start`: Attempts to start the service using the configuration for the local contrast agent.
+* `rake contrast:service:stop`: Attempts to stop the service. If the agent receives additional requests, it will attempt to restart the service on its own.
 
 ## Troubleshooting 
 
-### Multitple Agents
+### Multiple Agents
 
-*Ensure that the service host and port values are consistent.* Because the agent attempts to start the service on application startup, if there are multiple applications protected by the contrast agent, the first one to start will launch the service. This is not a problem since the service is designed to handle communication with multiple agents, however if the `agent.service.host` and `agent.service.port` configuration values don't match then the additional agent will be unable to communicate with the previously started service.
+**Ensure that the service host and port values are consistent.** If there are multiple applications protected by the Contrast agent, the first one to start will launch the service. This is not a problem since the service is designed to handle communication with multiple agents. But, if the `agent.service.host` and `agent.service.port` configuration values don't match,  the additional agent won't be able to communicate with the previously started service.
 
 ### Delay on First Request
 
-*Inventory and coverage metrics are gathered on first request.* The initial message to the Contrast UI containes information about the routes and Gems used by the application for inventory analysis. This is a relatively heavyweight process and may add a few seconds to the response time for the initial HTTP request to the application. Under some application servers (e.g. Puma) adding the `ruby.analyze_inventory_async: true` configuration can reduce this delay.
+**Inventory and coverage metrics are gathered on first request.** The initial message to the Contrast UI contains information about the routes and Gems used by the application for inventory analysis. This is a relatively heavyweight process, and may add a few seconds to the response time for the initial HTTP request to the application. Under some application servers (e.g., Puma) adding the `ruby.analyze_inventory_async: true` configuration can reduce this delay.
 

--- a/content/installation/ruby/RubyOverview.md
+++ b/content/installation/ruby/RubyOverview.md
@@ -8,7 +8,7 @@ The Contrast Ruby agent is a Protect-only agent that provides runtime protection
 
 ## About Ruby 
 
-The Ruby agent is a Rack middleware that's compatible with Ruby on Rails applications from version 3.0 and above and Sintra version 2.0 and above. It may also be compatible with other Rack-based web frameworks like Grape and Padrino.
+The Ruby agent is a Rack middleware that's compatible with Ruby on Rails applications from version 3.0 and above as well as Sintra version 2.0 and above. It may also be compatible with other Rack-based web frameworks like Grape and Padrino.
 
 From it's position within the Rack middleware stack, the Ruby agent inspects HTTP requests to identify potentially harmful input vectors. During the request, the agent inspects database queries, file writes and other potentially damaging actions resulting from the request. At the end of the request, the agent inspects the rendered output for successful attacks, and can block a successful attack from being forwarded to the application user. The service sends the details of the attack to the Contrast application, which then sends you an alert and displays attack details in the interface. 
 

--- a/content/installation/ruby/RubyOverview.md
+++ b/content/installation/ruby/RubyOverview.md
@@ -4,11 +4,11 @@ description: "Troubleshooting the Ruby Agent"
 tags: "installation Ruby on Rails agent troubleshooting"
 -->
 
-The Contrast Ruby agent provides runtime protection of Ruby on Rails web applications. 
+The Contrast Ruby agent is a Protect-only agent that provides runtime protection of Ruby on Rails web applications. 
 
 ## About Ruby 
 
-The Ruby agent is a Rack middleware that's compatible with Ruby on Rails installation from version 3.0 and above and Sintra version 2.0 and above. It may also be compatible with other Rack-based web frameworks like Grape. 
+The Ruby agent is a Rack middleware that's compatible with Ruby on Rails applications from version 3.0 and above and Sintra version 2.0 and above. It may also be compatible with other Rack-based web frameworks like Grape and Padrino.
 
 From it's position within the Rack middleware stack, the Ruby agent inspects HTTP requests to identify potentially harmful input vectors. During the request, the agent inspects database queries, file writes and other potentially damaging actions resulting from the request. At the end of the request, the agent inspects the rendered output for successful attacks, and can block a successful attack from being forwarded to the application user. The service sends the details of the attack to the Contrast application, which then sends you an alert and displays attack details in the interface. 
 
@@ -16,5 +16,5 @@ From it's position within the Rack middleware stack, the Ruby agent inspects HTT
 
 ## Use the Agent 
 
-To start protecting your application, download the Ruby agent and service, and create a configuration file as described in [Ruby Agent Installation](installation-ruby.html#ruby-install). The Ruby agent is installed as a standard Ruby Gem, and communicates with a standalone service that runs outside your application.
+To start protecting your application, download the Ruby agent and create a configuration file as described in [Ruby Agent Installation](installation-ruby.html#ruby-install). The Ruby agent is installed as a standard Ruby Gem.
 

--- a/content/installation/ruby/RubySupportedTechnologies.md
+++ b/content/installation/ruby/RubySupportedTechnologies.md
@@ -4,7 +4,7 @@ description: "List of supported technologies"
 tags: "installation Ruby on Rails agent frameworks support troubleshooting gem"
 -->
 
-The Ruby agent supports Ruby language version 2.1.x and above. Framework support is currently for Ruby on Rails versions 3.x and above and Sinatra 2.x and above. The Ruby agent is a standard Rack middleware and therefore it may work in other Rack-based web frameworks like Grape and Padrino. 
+The Ruby agent supports Ruby language version 2.1.x and above. Framework support is currently for Ruby on Rails versions 3.x and above as well as Sinatra 2.x and above. The Ruby agent is a standard Rack middleware; consequently, it may work in other Rack-based web frameworks like Grape and Padrino. 
 
 ## Database Support
 

--- a/content/installation/ruby/RubySupportedTechnologies.md
+++ b/content/installation/ruby/RubySupportedTechnologies.md
@@ -4,7 +4,7 @@ description: "List of supported technologies"
 tags: "installation Ruby on Rails agent frameworks support troubleshooting gem"
 -->
 
-The Ruby agent supports Ruby language version 2.1.x and above. Framework support is currently for Ruby on Rails versions 3.x and above and Sinatra 2.x and above. The Ruby agent is a standard Rack middleware; it may work in other Rack-based web frameworks like Sinatra. 
+The Ruby agent supports Ruby language version 2.1.x and above. Framework support is currently for Ruby on Rails versions 3.x and above and Sinatra 2.x and above. The Ruby agent is a standard Rack middleware and therefore it may work in other Rack-based web frameworks like Grape and Padrino. 
 
 ## Database Support
 
@@ -12,6 +12,6 @@ The Ruby Agent has SQL Injection modules for MySQL (`mysql2` gem), SQLite3 and P
 
 ## OS Support
 
-Agent testing is done on **64-bit OSX** and **64-bit Linux**. The agent has no *C* dependencies, and may work in other operating system environments. However, the associated service depends on Nokogiri and EventMachine, and may have trouble compiling under non-supported operating systems.
+Agent testing is done on **64-bit OSX** and **64-bit Linux**. The agent has *C* dependencies, and may not work in other operating system environments or under JRuby. 
 
 


### PR DESCRIPTION
The Contrast Protect agent 2.0 for ruby is scheduled to release to sass tomorrow so here's the updated instructions. 