### PR TITLE
:memo: CONTRAST-26111 Verify Java agent Exec Helper installation

### DIFF
--- a/content/installation/java/Java-linux-packages.md
+++ b/content/installation/java/Java-linux-packages.md
@@ -65,6 +65,15 @@ echo "deb https://contrastsecurity.jfrog.io/contrastsecurity/debian-staging/ $(b
 sudo apt-get update && sudo apt-get install contrast-java-agent-exec-helper
 ```
 
+* Verify that the Contrast Java Exec Helper is working by executing `java` and confirming that Contrast starts by observing console messages
+
+```
+$ bash -c "java -Dcontrast.stdout=true -version 2>1 | grep Contrast | head -n 1"
+[Contrast] Wed Aug 15 17:37:23 UTC 2018 No TeamServer configuration detected. Agent will only be reporting to local listeners (e.g., Eclipse Plugin).
+```
+
+* The Contrast Java agent Exec Helper affects all new shells (hence the `bash -c` in the verification command, so it will be present in your current shell; reload your shell to enable the Contrast Java agent Exec Helper. Restart any `java` services to enable Contrast for those services.
+
 > **Note:** The Exec Helper package expects to find the Contrast Java agent at */opt/contrast/contrast.jar*, where the `contrast-java-agent` package installs it. If the Contrast *jar* file has a different path, use environment variable `CONTRAST_JAVA_AGENT_PATH` to configure `contrast-java-agent-exec-helper`.
 
 
@@ -116,6 +125,15 @@ yum list installed contrast-java-agent
 ```
 yum install contrast-java-agent-exec-helper
 ```
+
+* Verify that the Contrast Java Exec Helper is working by executing `java` and confirming that Contrast starts by observing console messages
+
+```
+$ bash -c "java -Dcontrast.stdout=true -version 2>1 | grep Contrast | head -n 1"
+[Contrast] Wed Aug 15 17:37:23 UTC 2018 No TeamServer configuration detected. Agent will only be reporting to local listeners (e.g., Eclipse Plugin).
+```
+
+* The Contrast Java agent Exec Helper affects all new shells (hence the `bash -c` in the verification command, so it will be present in your current shell; reload your shell to enable the Contrast Java agent Exec Helper. Restart any `java` services to enable Contrast for those services.
 
 > **Note:** The Exec Helper package expects to find the Contrast Java agent at */opt/contrast/contrast.jar*, where the `contrast-java-agent` packages installs it. If the Contrast *jar* file has a different path, use environment variable `CONTRAST_JAVA_AGENT_PATH` to configure the `contrast-java-agent-exec-helper`.
 

--- a/content/installation/java/Java-linux-packages.md
+++ b/content/installation/java/Java-linux-packages.md
@@ -65,7 +65,7 @@ echo "deb https://contrastsecurity.jfrog.io/contrastsecurity/debian-staging/ $(b
 sudo apt-get update && sudo apt-get install contrast-java-agent-exec-helper
 ```
 
-* Verify that the Contrast Java Exec Helper is working by executing `java` and confirming that Contrast starts by observing console messages.
+* Verify that the Contrast Java Exec Helper is installed by executing `java` and confirming that Contrast starts by observing console messages.
 
 ```
 $ bash -c "java -Dcontrast.stdout=true -version 2>1 | grep Contrast | head -n 1"
@@ -73,6 +73,8 @@ $ bash -c "java -Dcontrast.stdout=true -version 2>1 | grep Contrast | head -n 1"
 ```
 
 * The Exec Helper affects all new shells - indicated by the `bash -c` in the verification command. Consequently, it will be present in your current shell. Reload your shell to enable the Exec Helper. Restart any `java` services to enable Contrast for those services.
+
+* The Exec Helper logs messages to the host's Syslog service using the identifier "Contrast". The Exec Helper uses the "user.warn" and "user.debug" Syslog facility and level, respectively. Use `journalctl` to view the messages (i.e., `journalctl -t Contrast`). Traditional init.v systems, including Ubuntu 14.04, store Syslog messages in the file */var/log/messages* by default instead of the systemd Journal.
 
 > **Note:** The Exec Helper package expects to find the Contrast Java agent at */opt/contrast/contrast.jar*, where the `contrast-java-agent` package installs it. If the Contrast *jar* file has a different path, use environment variable `CONTRAST_JAVA_AGENT_PATH` to configure `contrast-java-agent-exec-helper`.
 
@@ -134,6 +136,8 @@ $ bash -c "java -Dcontrast.stdout=true -version 2>1 | grep Contrast | head -n 1"
 ```
 
 * The Contrast Java agent Exec Helper affects all new shells - indicated by the `bash -c` in the verification command. Consequently, it will be present in your current shell. Reload your shell to enable the Contrast Java agent Exec Helper. Restart any `java` services to enable Contrast for those services.
+
+* The Exec Helper logs messages to the host's Syslog service using the identifier "Contrast". The Exec Helper uses the "user.warn" and "user.debug" Syslog facility and level, respectively. Use `journalctl` to view the messages (i.e., `journalctl -t Contrast`). Traditional init.v systems, including EL6, store Syslog messages in the file */var/log/messages* by default instead of the systemd Journal.
 
 > **Note:** The Exec Helper package expects to find the Contrast Java agent at */opt/contrast/contrast.jar*, where the `contrast-java-agent` packages installs it. If the Contrast *jar* file has a different path, use environment variable `CONTRAST_JAVA_AGENT_PATH` to configure the `contrast-java-agent-exec-helper`.
 

--- a/content/installation/java/Java-linux-packages.md
+++ b/content/installation/java/Java-linux-packages.md
@@ -39,7 +39,6 @@ sudo apt-get update && sudo apt-get install contrast-java-agent
 
 At this stage, you may either complete the agent installation process by follow the instructions for the [Java application container](installation-javainstall.html) of your choice, or continue on to **Add the Exec Helper** package. 
 
-
 ### Add the Exec Helper  
 
 The Exec Helper package for the Contrast Java agent supports Ubuntu LTS distributions Trusty, Xenial and Bionic. Complete the following steps to install the package. 
@@ -72,11 +71,13 @@ $ bash -c "java -Dcontrast.stdout=true -version 2>1 | grep Contrast | head -n 1"
 [Contrast] Wed Aug 15 17:37:23 UTC 2018 No TeamServer configuration detected. Agent will only be reporting to local listeners (e.g., Eclipse Plugin).
 ```
 
-* The Exec Helper affects all new shells - indicated by the `bash -c` in the verification command. Consequently, it will be present in your current shell. Reload your shell to enable the Exec Helper. Restart any `java` services to enable Contrast for those services.
-
-* The Exec Helper logs messages to the host's Syslog service using the identifier "Contrast". The Exec Helper uses the "user.warn" and "user.debug" Syslog facility and level, respectively. Use `journalctl` to view the messages (i.e., `journalctl -t Contrast`). Traditional init.v systems, including Ubuntu 14.04, store Syslog messages in the file */var/log/messages* by default instead of the systemd Journal.
+* The Exec Helper affects all new shells, as indicated by the `bash -c` in the verification command. Consequently, it will be present in your current shell. Reload your shell to enable the Exec Helper. Restart any `java` services to enable Contrast for those services.
 
 > **Note:** The Exec Helper package expects to find the Contrast Java agent at */opt/contrast/contrast.jar*, where the `contrast-java-agent` package installs it. If the Contrast *jar* file has a different path, use environment variable `CONTRAST_JAVA_AGENT_PATH` to configure `contrast-java-agent-exec-helper`.
+
+#### Logging 
+
+The Exec Helper logs messages to the host's Syslog service using the identifier "Contrast". The Exec Helper uses the "user.warn" and "user.debug" Syslog facility and level, respectively. Use `journalctl` to view the messages (i.e., `journalctl -t Contrast`). Traditional init.v systems, including Ubuntu 14.04, store Syslog messages in the file */var/log/messages* by default instead of the systemd Journal.
 
 
 ## Red Hat-Based Systems
@@ -135,12 +136,13 @@ $ bash -c "java -Dcontrast.stdout=true -version 2>1 | grep Contrast | head -n 1"
 [Contrast] Wed Aug 15 17:37:23 UTC 2018 No TeamServer configuration detected. Agent will only be reporting to local listeners (e.g., Eclipse Plugin).
 ```
 
-* The Contrast Java agent Exec Helper affects all new shells - indicated by the `bash -c` in the verification command. Consequently, it will be present in your current shell. Reload your shell to enable the Contrast Java agent Exec Helper. Restart any `java` services to enable Contrast for those services.
-
-* The Exec Helper logs messages to the host's Syslog service using the identifier "Contrast". The Exec Helper uses the "user.warn" and "user.debug" Syslog facility and level, respectively. Use `journalctl` to view the messages (i.e., `journalctl -t Contrast`). Traditional init.v systems, including EL6, store Syslog messages in the file */var/log/messages* by default instead of the systemd Journal.
+* The Contrast Java agent Exec Helper affects all new shells, as indicated by the `bash -c` in the verification command. Consequently, it will be present in your current shell. Reload your shell to enable the Contrast Java agent Exec Helper. Restart any `java` services to enable Contrast for those services.
 
 > **Note:** The Exec Helper package expects to find the Contrast Java agent at */opt/contrast/contrast.jar*, where the `contrast-java-agent` packages installs it. If the Contrast *jar* file has a different path, use environment variable `CONTRAST_JAVA_AGENT_PATH` to configure the `contrast-java-agent-exec-helper`.
 
+#### Logging
+
+The Exec Helper logs messages to the host's Syslog service using the identifier "Contrast". The Exec Helper uses the "user.warn" and "user.debug" Syslog facility and level, respectively. Use `journalctl` to view the messages (i.e., `journalctl -t Contrast`). Traditional init.v systems, including EL6, store Syslog messages in the file */var/log/messages* by default instead of the systemd Journal.
 
 ## Remove the Agent
 
@@ -150,5 +152,6 @@ If you need to uninstall the Java agent, use the appropriate command for each pa
 
 * To remove the `contrast-java-agent-exec-helper` package, run `apt-get remove contrast-java-agent-exec-helper`. 
 
+## Learn More 
 
-
+If you're experiencing issues with the Exec Helper package after installation, go to the [troubleshooting article](troubleshooting-javainstall.html#java-exec) for more help with startup, logging and libraries. 

--- a/content/installation/java/Java-linux-packages.md
+++ b/content/installation/java/Java-linux-packages.md
@@ -65,14 +65,14 @@ echo "deb https://contrastsecurity.jfrog.io/contrastsecurity/debian-staging/ $(b
 sudo apt-get update && sudo apt-get install contrast-java-agent-exec-helper
 ```
 
-* Verify that the Contrast Java Exec Helper is working by executing `java` and confirming that Contrast starts by observing console messages
+* Verify that the Contrast Java Exec Helper is working by executing `java` and confirming that Contrast starts by observing console messages.
 
 ```
 $ bash -c "java -Dcontrast.stdout=true -version 2>1 | grep Contrast | head -n 1"
 [Contrast] Wed Aug 15 17:37:23 UTC 2018 No TeamServer configuration detected. Agent will only be reporting to local listeners (e.g., Eclipse Plugin).
 ```
 
-* The Contrast Java agent Exec Helper affects all new shells (hence the `bash -c` in the verification command, so it will be present in your current shell; reload your shell to enable the Contrast Java agent Exec Helper. Restart any `java` services to enable Contrast for those services.
+* The Exec Helper affects all new shells - indicated by the `bash -c` in the verification command. Consequently, it will be present in your current shell. Reload your shell to enable the Exec Helper. Restart any `java` services to enable Contrast for those services.
 
 > **Note:** The Exec Helper package expects to find the Contrast Java agent at */opt/contrast/contrast.jar*, where the `contrast-java-agent` package installs it. If the Contrast *jar* file has a different path, use environment variable `CONTRAST_JAVA_AGENT_PATH` to configure `contrast-java-agent-exec-helper`.
 
@@ -126,14 +126,14 @@ yum list installed contrast-java-agent
 yum install contrast-java-agent-exec-helper
 ```
 
-* Verify that the Contrast Java Exec Helper is working by executing `java` and confirming that Contrast starts by observing console messages
+* Verify that the Exec Helper is working by executing `java` and confirming that Contrast starts by observing console messages.
 
 ```
 $ bash -c "java -Dcontrast.stdout=true -version 2>1 | grep Contrast | head -n 1"
 [Contrast] Wed Aug 15 17:37:23 UTC 2018 No TeamServer configuration detected. Agent will only be reporting to local listeners (e.g., Eclipse Plugin).
 ```
 
-* The Contrast Java agent Exec Helper affects all new shells (hence the `bash -c` in the verification command, so it will be present in your current shell; reload your shell to enable the Contrast Java agent Exec Helper. Restart any `java` services to enable Contrast for those services.
+* The Contrast Java agent Exec Helper affects all new shells - indicated by the `bash -c` in the verification command. Consequently, it will be present in your current shell. Reload your shell to enable the Contrast Java agent Exec Helper. Restart any `java` services to enable Contrast for those services.
 
 > **Note:** The Exec Helper package expects to find the Contrast Java agent at */opt/contrast/contrast.jar*, where the `contrast-java-agent` packages installs it. If the Contrast *jar* file has a different path, use environment variable `CONTRAST_JAVA_AGENT_PATH` to configure the `contrast-java-agent-exec-helper`.
 


### PR DESCRIPTION
Adding instructions for the user to verify their installation of the Contrast Java agent Exec Helper. Additionally, added a note to explain that Contrast Java agent Exec Helper is only enabled in new shells

In developing the command for users to verify the Contrast Java agent Exec Helper, I made the assumption that the user is likely to copy paste this command. Given this assumption, I felt free to make this command a bit more complicated than it needs to be in order to improve the output it generates.

The command I included is `bash -c "java -Dcontrast.stdout=true -version 2>1 | grep Contrast | head -n 1"` which in addition to being more complicated, assumes that the user has programs `grep` and `head` available (which is a safe assumption, but not a guarantee). This command generates one neat line of output

> [Contrast] Wed Aug 15 17:37:23 UTC 2018 No TeamServer configuration detected. Agent will only be reporting to local listeners (e.g., Eclipse Plugin).

Alternatively, the simplest command that could work is `bash -c "java -Dcontrast.stdout=true -version"`, but it vomits a huge number of console messages which I feel distracts the user from the task at hand