### PR TITLE
coverage note re: unsupported frameworks

### DIFF
--- a/content/user/apps/Route-coverage.md
+++ b/content/user/apps/Route-coverage.md
@@ -25,9 +25,10 @@ For supported frameworks, route coverage consists of two parts:
 * **Discovered** routes: the full list of routes that Contrast has detected in an application 
 * **Observed** routes: the routes in which Contrast has detected traffic
 
-<!-- the full list of routes that Contrast has **discovered** in an application, and routes in which Contrast has **observed** traffic.  --> For unsupported frameworks, Contrast displays the observed routes only. 
+While coverage is enabled automatically for most Contrast agents, you must use the following property to specify the application name when deploying the **Java** agent: `-Dcontrast.standalone.appname=<example_name>`. If you don't include this property, the Java agent may only observe - but not discover - routes in your application. 
 
-While coverage is enabled automatically for most Contrast agents, you must use the following property to specify the application name when deploying the **Java** agent: `-Dcontrast.standalone.appname=<example_name>`. If you don't include this property, the Java agent may only observe - but not discover - routes in your application.  
+> **Note:** The **Java** and **Node** agents only report coverage information for the specifically instrumented frameworks listed above. For **unsupported frameworks**, neither agent displays any routes.
+
 
 ## View Route Details 
 


### PR DESCRIPTION
Article at https://docs.contrastsecurity.com/user-apps.html#route states, "For unsupported frameworks, Contrast displays the observed routes only." Statement must be revised to reflect more accurate explanations given by each agent/engineer.