### PR TITLE
adding certificate sections for service; also applies to ruby and python

### DIFF
--- a/content/installation/node/NodeConfig.md
+++ b/content/installation/node/NodeConfig.md
@@ -16,8 +16,8 @@ Parameter                                      | Environment Variable           
 --contrast.service_key <key>                   | CONTRAST\_\_SERVICE_KEY                        | Account service key.
 --contrast.url <url>                           | CONTRAST\_\_URL                                | URL on which to report. Default is https://app.contrastsecurity.com/.
 --contrast.user_name <name>                    | CONTRAST\_\_USER_NAME                          | Account user name.
---contrast.ca_file <path>                      | CONTRAST\_\_CA_FILE                            | When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the relative or absolute path to your CA file.
---contrast.ignore_cert_errors [true]           | CONTRAST\_\_IGNORE_CERT_ERRORS                 | Allows agent to communicate data even if Contrast's cert can't be verified against supplied list of CAs.
+--contrast.ca_file <path>                      | CONTRAST\_\_CERTIFICATE\_\_CA_FILE             | When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the relative or absolute path to your CA file.
+--contrast.ignore_cert_errors [true]           | CONTRAST\_\_CERTIFICATE\_\_IGNORE_CERT_ERRORS  | Allows agent to communicate data even if Contrast's cert can't be verified against supplied list of CAs.
 --contrast.proxy.enable [true]                 | CONTRAST\_\_PROXY\_\_ENABLE                    | If `false`, no proxy is being used for communication of data.
 --contrast.proxy.url <url>                     | CONTRAST\_\_PROXY\_\_URL                       | URL of proxy for communicating agent data.
 --contrast.timeout_ms <ms>                     | CONTRAST\_\_TIMEOUT_MS                         | Http timeout value (in ms). Default is **10000**.

--- a/content/installation/node/NodeConfig.md
+++ b/content/installation/node/NodeConfig.md
@@ -19,8 +19,8 @@ Parameter                                      | Environment Variable           
 --contrast.proxy.enable [true]                 | CONTRAST\_\_PROXY\_\_ENABLE                    | If `false`, no proxy is being used for communication of data.
 --contrast.proxy.url <url>                     | CONTRAST\_\_PROXY\_\_URL                       | URL of proxy for communicating agent data.
 --contrast.timeout_ms <ms>                     | CONTRAST\_\_TIMEOUT_MS                         | Http timeout value (in ms). Default is **10000**.
---contrast.certificate.ca_file <path>          | CONTRAST\_\_CERTIFICATE\_\_CA_FILE             | When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the relative or absolute path to your CA file.
---contrast.certificate.ignore_cert_errors [true] | CONTRAST\_\_CERTIFICATE\_\_IGNORE_CERT_ERRORS  | Allows agent to communicate data even if Contrast's cert can't be verified against supplied list of CAs.
+--contrast.certificate.ca_file <path>          | CONTRAST\_\_CERTIFICATE\_\_CA_FILE             | When running an Enterprise-on-Premises (EOP) Contrast instance using a self-signed certificate, use this option to provide the relative or absolute path to your CA file.
+--contrast.certificate.ignore_cert_errors [true] | CONTRAST\_\_CERTIFICATE\_\_IGNORE_CERT_ERRORS  | Allows the agent to communicate data, even if Contrast's cert can't be verified against supplied list of CAs.
 --agent.auto_update [false]                    | AGENT\_\_AUTO_UPDATE                           | If `false`, don't attempt to auto-update the agent. Default is `true`.
 --agent.auto_update_path <path>                | AGENT\_\_AUTO_UPDATE_PATH                      | Directory where the updated agent artifact should be saved before installation. Default is */var/folders/ck/4cpmx4m569j29z7n05dnfb4h0000gp/T*.
 --agent.auto_update_timeout_ms <ms>            | AGENT\_\_AUTO_UPDATE_TIMEOUT_MS                | Time to wait before aborting auto-update attempt. Default is **60000**.

--- a/content/installation/node/NodeConfig.md
+++ b/content/installation/node/NodeConfig.md
@@ -16,11 +16,11 @@ Parameter                                      | Environment Variable           
 --contrast.service_key <key>                   | CONTRAST\_\_SERVICE_KEY                        | Account service key.
 --contrast.url <url>                           | CONTRAST\_\_URL                                | URL on which to report. Default is https://app.contrastsecurity.com/.
 --contrast.user_name <name>                    | CONTRAST\_\_USER_NAME                          | Account user name.
---contrast.ca_file <path>                      | CONTRAST\_\_CERTIFICATE\_\_CA_FILE             | When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the relative or absolute path to your CA file.
---contrast.ignore_cert_errors [true]           | CONTRAST\_\_CERTIFICATE\_\_IGNORE_CERT_ERRORS  | Allows agent to communicate data even if Contrast's cert can't be verified against supplied list of CAs.
 --contrast.proxy.enable [true]                 | CONTRAST\_\_PROXY\_\_ENABLE                    | If `false`, no proxy is being used for communication of data.
 --contrast.proxy.url <url>                     | CONTRAST\_\_PROXY\_\_URL                       | URL of proxy for communicating agent data.
 --contrast.timeout_ms <ms>                     | CONTRAST\_\_TIMEOUT_MS                         | Http timeout value (in ms). Default is **10000**.
+--contrast.certificate.ca_file <path>          | CONTRAST\_\_CERTIFICATE\_\_CA_FILE             | When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the relative or absolute path to your CA file.
+--contrast.certificate.ignore_cert_errors [true] | CONTRAST\_\_CERTIFICATE\_\_IGNORE_CERT_ERRORS  | Allows agent to communicate data even if Contrast's cert can't be verified against supplied list of CAs.
 --agent.auto_update [false]                    | AGENT\_\_AUTO_UPDATE                           | If `false`, don't attempt to auto-update the agent. Default is `true`.
 --agent.auto_update_path <path>                | AGENT\_\_AUTO_UPDATE_PATH                      | Directory where the updated agent artifact should be saved before installation. Default is */var/folders/ck/4cpmx4m569j29z7n05dnfb4h0000gp/T*.
 --agent.auto_update_timeout_ms <ms>            | AGENT\_\_AUTO_UPDATE_TIMEOUT_MS                | Time to wait before aborting auto-update attempt. Default is **60000**.

--- a/content/installation/python/PythonConfig.md
+++ b/content/installation/python/PythonConfig.md
@@ -31,6 +31,9 @@ Use the properties in this section to connect the agent to the Contrast UI.
   * **service_key**: Set the service key needed to communicate with the Contrast UI. It is used to calculate the Authorization header. **Required.**
   * **user_name**: Set the user name used to communicate with the Contrast UI. It is used to calculate the Authorization header. **Required.**
   * **last_config_path**: Set the path to which the agent should store the currently used configuration from the Contrast UI. <br> Example: *./tmp/config*
+  * **ca_file**: When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the path to a custom CA file.
+  * **cert_pem_file**: Optionally provide a path to the server's certificate PEM file.
+  * **key_pem_file**: Optionally provide a path to the server's key PEM file.
 
 ### Contrast agent properties
 
@@ -43,7 +46,7 @@ Define the following properties to set logging values. If these properties aren'
 * **agent**: Options for communicating between the agent and the service
   * **logger**:
     * **path**: Enable diagnostic logging by setting a path to a log file. While diagnostic logging hurts performance, it generates useful information for debugging Contrast. The value set here is the location to which the agent saves log output. If no log file exists at this location, the agent creates a file. <br> Example - */opt/Contrast/contrast.log* creates a log in the */opt/Contrast* directory, and rotates it automatically as needed.
-    * **level**: Set the the log output level. Value options are `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, and `ALL`.
+    * **level**: Set the the log output level. Value options are `ERROR`, `WARN`, `INFO`, and `DEBUG`.
     * **progname**: Set the name the agent uses to identify the process within the log file <br> Example: Contrast Agent
 
 #### Security logger
@@ -87,7 +90,7 @@ The following properties are used by the logger in the Contrast service. If the 
 
   * **logger**:
     * **path**: Set the location to which the Contrast service saves log output. If no log file exists at this location, the service creates one. <br> Example: */opt/Contrast/contrast_service.log* will create a log in the */opt/Contrast* directory.
-    * **level**: Set the the log output level. Options are `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, and `ALL`.
+    * **level**: Set the the log output level. Value options are `ERROR`, `WARN`, `INFO`, and `DEBUG`.
     * **progname**: Set the name the agent uses to identify the process within the service log file <br> Example: Contrast Agent
 
 

--- a/content/installation/python/PythonConfig.md
+++ b/content/installation/python/PythonConfig.md
@@ -30,10 +30,10 @@ Use the properties in this section to connect the agent to the Contrast UI.
   * **api_key**: Set the API key needed to communicate with the Contrast UI. **Required.**
   * **service_key**: Set the service key needed to communicate with the Contrast UI. It is used to calculate the Authorization header. **Required.**
   * **user_name**: Set the user name used to communicate with the Contrast UI. It is used to calculate the Authorization header. **Required.**
-  * **last_config_path**: Set the path to which the agent should store the currently used configuration from the Contrast UI. <br> Example: *./tmp/config*
-  * **ca_file**: When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the path to a custom CA file.
-  * **cert_pem_file**: Optionally provide a path to the server's certificate PEM file.
-  * **key_pem_file**: Optionally provide a path to the server's key PEM file.
+  * **certificate**: This optional section allows the use of custom or self-signed certificate authority and certificate files when connecting to the Contrast UI.
+    * **ca_file**: When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the path to a custom CA file.
+    * **cert_file**: Optionally provide a path to the server's certificate PEM file.
+    * **key_file**: Optionally provide a path to the server's key PEM file.
 
 ### Contrast agent properties
 

--- a/content/installation/python/PythonConfig.md
+++ b/content/installation/python/PythonConfig.md
@@ -30,10 +30,10 @@ Use the properties in this section to connect the agent to the Contrast UI.
   * **api_key**: Set the API key needed to communicate with the Contrast UI. **Required.**
   * **service_key**: Set the service key needed to communicate with the Contrast UI. It is used to calculate the Authorization header. **Required.**
   * **user_name**: Set the user name used to communicate with the Contrast UI. It is used to calculate the Authorization header. **Required.**
-  * **certificate**: This optional section allows the use of custom or self-signed certificate authority and certificate files when connecting to the Contrast UI.
-    * **ca_file**: When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the path to a custom CA file.
-    * **cert_file**: Optionally provide a path to the server's certificate PEM file.
-    * **key_file**: Optionally provide a path to the server's key PEM file.
+  * **certificate**: Allow the use of custom or self-signed certificate authority and certificate files when connecting to the Contrast UI.
+    * **ca_file**: When running an Enterprise-on-Premises (EOP) Contrast instance using a self-signed certificate, use this option to provide the path to a custom CA file.
+    * **cert_file**: Provide a path to the server's certificate PEM file.
+    * **key_file**: Provide a path to the server's key PEM file.
 
 ### Contrast agent properties
 

--- a/content/installation/ruby/RubyConfig.md
+++ b/content/installation/ruby/RubyConfig.md
@@ -44,6 +44,9 @@ Use the properties in this section to connect the agent to the Contrast UI.
   * **service_key**: Set the service key needed to communicate with the Contrast UI. It is used to calculate the Authorization header. **Required.**
   * **user_name**: Set the user name used to communicate with the Contrast UI. It is used to calculate the Authorization header. **Required.**
   * **last_config_path**: Set the path to which the agent should store the currently used configuration from the Contrast UI. <br> Example: *./tmp/config*
+  * **ca_file**: When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the path to a custom CA file.
+  * **cert_pem_file**: Optionally provide a path to the server's certificate PEM file.
+  * **key_pem_file**: Optionally provide a path to the server's key PEM file.
 
 ### Contrast agent properties
 
@@ -56,7 +59,7 @@ Define the following properties to set logging values. If these properties aren'
 * **agent**: Options for communicating between the agent and the service
   * **logger**:
     * **path**: Enable diagnostic logging by setting a path to a log file. While diagnostic logging hurts performance, it generates useful information for debugging Contrast. The value set here is the location to which the agent saves log output. If no log file exists at this location, the agent creates a file. <br> Example - */opt/Contrast/contrast.log* creates a log in the */opt/Contrast* directory, and rotates it automatically as needed.
-    * **level**: Set the the log output level. Value options are `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, and `ALL`.
+    * **level**: Set the the log output level. Value options are `ERROR`, `WARN`, `INFO`, and `DEBUG`.
     * **progname**: Override the name of the process the agents uses in logs. <br> Example: Contrast Agent
     * **metrics**: Set to `true` for the agent to tag logs with "!AM!" for the metrics tool.
 
@@ -101,7 +104,7 @@ The following properties are used by the logger in the Contrast service. If the 
 
   * **logger**:
     * **path**: Set the location to which the Contrast service saves log output. If no log file exists at this location, the service creates one. <br> Example: */opt/Contrast/contrast_service.log* will create a log in the */opt/Contrast* directory.
-    * **level**: Set the the log output level. Options are `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, and `ALL`.
+    * **level**: Set the the log output level. Value options are `ERROR`, `WARN`, `INFO`, and `DEBUG`.
     * **progname**: Override the name of the process used in logs. <br> Example: Contrast Service
 
 <!-- ### Ruby-specific properties

--- a/content/installation/ruby/RubyConfig.md
+++ b/content/installation/ruby/RubyConfig.md
@@ -43,10 +43,10 @@ Use the properties in this section to connect the agent to the Contrast UI.
   * **api_key**: Set the API key needed to communicate with the Contrast UI. **Required.**
   * **service_key**: Set the service key needed to communicate with the Contrast UI. It is used to calculate the Authorization header. **Required.**
   * **user_name**: Set the user name used to communicate with the Contrast UI. It is used to calculate the Authorization header. **Required.**
-  * **certificate**: This optional section allows the use of custom or self-signed certificate authority and certificate files when connecting to the Contrast UI.
-    * **ca_file**: When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the path to a custom CA file.
-    * **cert_file**: Optionally provide a path to the server's certificate PEM file.
-    * **key_file**: Optionally provide a path to the server's key PEM file.
+  * **certificate**: Allow the use of custom or self-signed certificate authority and certificate files when connecting to the Contrast UI.
+    * **ca_file**: When running an Enterprise-on-Premises (EOP) Contrast instance using a self-signed certificate, use this option to provide the path to a custom CA file.
+    * **cert_file**: Provide a path to the server's certificate PEM file.
+    * **key_file**: Provide a path to the server's key PEM file.
 
 ### Contrast agent properties
 

--- a/content/installation/ruby/RubyConfig.md
+++ b/content/installation/ruby/RubyConfig.md
@@ -43,10 +43,10 @@ Use the properties in this section to connect the agent to the Contrast UI.
   * **api_key**: Set the API key needed to communicate with the Contrast UI. **Required.**
   * **service_key**: Set the service key needed to communicate with the Contrast UI. It is used to calculate the Authorization header. **Required.**
   * **user_name**: Set the user name used to communicate with the Contrast UI. It is used to calculate the Authorization header. **Required.**
-  * **last_config_path**: Set the path to which the agent should store the currently used configuration from the Contrast UI. <br> Example: *./tmp/config*
-  * **ca_file**: When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the path to a custom CA file.
-  * **cert_pem_file**: Optionally provide a path to the server's certificate PEM file.
-  * **key_pem_file**: Optionally provide a path to the server's key PEM file.
+  * **certificate**: This optional section allows the use of custom or self-signed certificate authority and certificate files when connecting to the Contrast UI.
+    * **ca_file**: When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the path to a custom CA file.
+    * **cert_file**: Optionally provide a path to the server's certificate PEM file.
+    * **key_file**: Optionally provide a path to the server's key PEM file.
 
 ### Contrast agent properties
 

--- a/content/installation/service/ServiceConfig.md
+++ b/content/installation/service/ServiceConfig.md
@@ -19,22 +19,39 @@ The configuration file is titled *contrast_security.yaml* no matter where it's l
 
 The configuration YAML consists of four sections. The agent and Service may share a common configuration file, but only some options and sections are applicable to each process.
 
-* `contrast`: Use the properties in this section to connect the agent to the Contrast UI. If you're using separate configuration files for the agents and service, you should define the options for connecting with Contrast UI for the Service.
-  * `url`: Set the URL for the Contrast UI.
-  * `api_key`: Set the API key needed to communicate with the Contrast UI.
-  * `service_key`: Set the service key needed to communicate with the Contrast UI. It is used to calculate the Authorization header.
-  * `user_name`: Set the user name used to communicate with the Contrast UI. It is used to calculate the Authorization header.
-* `agent`: Use the properties in this section to control the way and frequency with which the agent communicates to logs and the Contrast UI.
-    * `service`:
-      * `host`: Set the the hostname or IP address of the Contrast Service to which the Contrast agent should report. <br> Example: `localhost`
-      * `port`: Set the the port of the Contrast Service to which the Contrast agent should report. <br> Example: `30555`
-      <!-- * `socket`: For the **Webserver agent** only: If this property is defined, the Service is listening on a Unix socket at the defined path. <br> Example: */run/contrast-security.sock* -->
-      * `logger`:
-        * `path`: Set the location to which the Contrast Service saves log output. If no log file exists at this location, the Service creates one. <br> Example: */opt/Contrast/contrast_service.log* will create a log in the */opt/Contrast* directory.
-        * `level`: Set the the log output level. Options are `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, and `ALL`.
-        * `progname`: Override the name of the process used in logs. <br> Example: Contrast Service
-* `server`: Use the properties in this section to set metadata for the server hosting this agent. <br> Example: `test-server-1`
-  * `name`: Override the reported server name.
-  * `environment`: Override the reported server environment. <br> Example: `development`
-  * `tags`: Apply a list of labels to the server. Labels must be formatted as a comma-delimited list. <br> Example: label1,label2,label3 
+### Contrast UI properties
+
+Use the properties in this section to connect the agent to the Contrast UI.
+
+* **contrast**: 
+  * **url**: Set the URL for the Contrast UI.
+  * **api_key**: Set the API key needed to communicate with the Contrast UI.
+  * **service_key**: Set the service key needed to communicate with the Contrast UI. It is used to calculate the Authorization header.
+  * **user_name**: Set the user name used to communicate with the Contrast UI. It is used to calculate the Authorization header.
+  * **ca_file**: When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the path to a custom CA file.
+  * **cert_pem_file**: Optionally provide a path to the server's certificate PEM file.
+  * **key_pem_file**: Optionally provide a path to the server's key PEM file.
+
+### Contrast agent properties
+
+The options under this section allow the agents to find and communicate with the Contrast Service.
+
+* **agent**: Use the properties in this section to control the way and frequency with which the agent communicates to logs and the Contrast UI.
+  * **service**:
+    * **host**: Set the the hostname or IP address of the Contrast Service to which the Contrast agent should report. <br> Example: **localhost**
+    * **port**: Set the the port of the Contrast Service to which the Contrast agent should report. <br> Example: **30555**
+    * **socket**: For the **Webserver agent** only: If this property is defined, the Service is listening on a Unix socket at the defined path. <br> Example: */run/contrast-security.sock*
+    * **logger**:
+      * **path**: Set the location to which the Contrast Service saves log output. If no log file exists at this location, the Service creates one. <br> Example: */opt/Contrast/contrast_service.log* will create a log in the */opt/Contrast* directory.
+      * **level**: Set the the log output level. Options are **ERROR**, **WARN**, **INFO**, and **DEBUG**.
+      * **progname**: Override the name of the process used in logs. <br> Example: Contrast Service
+
+### Server properties
+
+The options under this section allow for overriding the server information sent to Contrast UI.
+
+* **server**: Use the properties in this section to set metadata for the server hosting this agent. <br> Example: **test-server-1**
+  * **name**: Override the reported server name.
+  * **environment**: Override the reported server environment. <br> Example: **development**
+  * **tags**: Apply a list of labels to the server. Labels must be formatted as a comma-delimited list. <br> Example: label1,label2,label3 
 

--- a/content/installation/service/ServiceConfig.md
+++ b/content/installation/service/ServiceConfig.md
@@ -28,31 +28,31 @@ Use the properties in this section to connect the agent to the Contrast UI.
   * **api_key**: Set the API key needed to communicate with the Contrast UI.
   * **service_key**: Set the service key needed to communicate with the Contrast UI. It is used to calculate the Authorization header.
   * **user_name**: Set the user name used to communicate with the Contrast UI. It is used to calculate the Authorization header.
-  * **certificate**: This optional section allows the use of custom or self-signed certificate authority and certificate files when connecting to the Contrast UI.
-    * **ca_file**: When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the path to a custom CA file.
-    * **cert_file**: Optionally provide a path to the server's certificate PEM file.
-    * **key_file**: Optionally provide a path to the server's key PEM file.
+  * **certificate**: Allow the use of custom or self-signed certificate authority and certificate files when connecting to the Contrast UI.
+    * **ca_file**: When running an Enterprise-on-Premises (EOP) Contrast instance using a self-signed certificate, use this option to provide the path to a custom CA file.
+    * **cert_file**: Provide a path to the server's certificate PEM file.
+    * **key_file**: Provide a path to the server's key PEM file.
 
 ### Contrast agent properties
 
-The options under this section allow the agents to find and communicate with the Contrast Service.
+Use the options in this section to allow the agents to find and communicate with the Contrast Service.
 
 * **agent**: Use the properties in this section to control the way and frequency with which the agent communicates to logs and the Contrast UI.
   * **service**:
-    * **host**: Set the the hostname or IP address of the Contrast Service to which the Contrast agent should report. <br> Example: **localhost**
-    * **port**: Set the the port of the Contrast Service to which the Contrast agent should report. <br> Example: **30555**
-    * **socket**: For the **Webserver agent** only: If this property is defined, the Service is listening on a Unix socket at the defined path. <br> Example: */run/contrast-security.sock*
+    * **host**: Set the the hostname or IP address of the Contrast Service to which the Contrast agent should report. <br> Example: `localhost`
+    * **port**: Set the the port of the Contrast Service to which the Contrast agent should report. <br> Example: `30555`
+    * **socket**: Set for or the **Webserver agent** only. If this property is defined, the Service is listening on a Unix socket at the defined path. <br> Example: */run/contrast-security.sock*
     * **logger**:
       * **path**: Set the location to which the Contrast Service saves log output. If no log file exists at this location, the Service creates one. <br> Example: */opt/Contrast/contrast_service.log* will create a log in the */opt/Contrast* directory.
-      * **level**: Set the the log output level. Options are **ERROR**, **WARN**, **INFO**, and **DEBUG**.
+      * **level**: Set the the log output level. Value options are `ERROR`, `WARN`, `INFO`, and `DEBUG`.
       * **progname**: Override the name of the process used in logs. <br> Example: Contrast Service
 
 ### Server properties
 
-The options under this section allow for overriding the server information sent to Contrast UI.
+Use the options in this section to override the server information sent to Contrast UI.
 
-* **server**: Use the properties in this section to set metadata for the server hosting this agent. <br> Example: **test-server-1**
+* **server**: Use the properties in this section to set metadata for the server hosting this agent. <br> Example: `test-server-1`
   * **name**: Override the reported server name.
-  * **environment**: Override the reported server environment. <br> Example: **development**
-  * **tags**: Apply a list of labels to the server. Labels must be formatted as a comma-delimited list. <br> Example: label1,label2,label3 
+  * **environment**: Override the reported server environment. <br> Example: `development`
+  * **tags**: Apply a list of labels to the server. Labels must be formatted as a comma-delimited list. <br> Example: `label1,label2,label3`
 

--- a/content/installation/service/ServiceConfig.md
+++ b/content/installation/service/ServiceConfig.md
@@ -28,9 +28,10 @@ Use the properties in this section to connect the agent to the Contrast UI.
   * **api_key**: Set the API key needed to communicate with the Contrast UI.
   * **service_key**: Set the service key needed to communicate with the Contrast UI. It is used to calculate the Authorization header.
   * **user_name**: Set the user name used to communicate with the Contrast UI. It is used to calculate the Authorization header.
-  * **ca_file**: When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the path to a custom CA file.
-  * **cert_pem_file**: Optionally provide a path to the server's certificate PEM file.
-  * **key_pem_file**: Optionally provide a path to the server's key PEM file.
+  * **certificate**: This optional section allows the use of custom or self-signed certificate authority and certificate files when connecting to the Contrast UI.
+    * **ca_file**: When running an on-premises Contrast instance using a self-signed certificate, use this option to provide the path to a custom CA file.
+    * **cert_file**: Optionally provide a path to the server's certificate PEM file.
+    * **key_file**: Optionally provide a path to the server's key PEM file.
 
 ### Contrast agent properties
 


### PR DESCRIPTION
Added the ca_path, cert and key path options. Fixed an error in the valid logging settings for dynamic agents. Changed config keys for service from `code` to **bold**