### PR TITLE
webserver agent install documentation

### DIFF
--- a/content/installation/linux_package_repo/ContrastRepoConfig.md
+++ b/content/installation/linux_package_repo/ContrastRepoConfig.md
@@ -1,0 +1,51 @@
+Some of Contrast's products are distributed via Linux packages. This makes
+installing and staying up to date very easy. In order to use our package repo
+you have to configure your package management system to include a reference to
+our package repo. The instructions for doing this are below:
+
+Some of our packages are tied to the specific Linux distribution you are using;
+For Ubuntu, this could be one of 'bionic', 'xenial', or 'trusty'.  The
+instructions will show you how to get this information and then use it to
+configure the right package repo for your system.  This is a one-time
+configuration.  Once its done, you'll be connected to the software distribution
+pipeline and can solely manage it via your distribution's package manager.
+
+### Debian/Ubuntu
+
+
+* Configure your system to retrieve from the correct Debian repository. Get the `CODENAME` for your Ubuntu/Debian release. 
+
+```
+grep VERSION_CODENAME /etc/os-release 
+```
+
+* Update the command below with the `CODENAME`, and run the commands.
+
+```
+curl https://contrastsecurity.jfrog.io/contrastsecurity/api/gpg/key/public | sudo apt-key add -
+echo "deb https://contrastsecurity.jfrog.io/contrastsecurity/debian-public/ CODENAME contrast" | sudo tee /etc/apt/sources.list.d/contrast.list
+```
+
+* Once you've finished configuration, update your local package cache
+
+```
+sudo apt-get update
+```
+
+### RedHat/CentOS
+
+Complete the following steps to install the Contrast Service for Red Hat Enterprise Linux (RHEL) and CentOS versions 5, 6 and 7.
+
+* To install Contrast Service from Contrast's Yum repository, configure your system to use the repository.
+
+```
+OSREL=$(rpmquery -E "%{rhel}")
+sudo -E tee /etc/yum.repos.d/contrast.repo << EOF
+[contrast]
+name=contrast repo
+baseurl=https://contrastsecurity.jfrog.io/contrastsecurity/rpm-public/centos-$OSREL/
+gpgcheck=0
+enabled=1
+EOF
+```
+

--- a/content/installation/linux_package_repo/ContrastRepoConfig.md
+++ b/content/installation/linux_package_repo/ContrastRepoConfig.md
@@ -4,7 +4,7 @@ you have to configure your package management system to include a reference to
 our package repo. The instructions for doing this are below:
 
 Some of our packages are tied to the specific Linux distribution you are using;
-For Ubuntu, this could be one of 'bionic', 'xenial', or 'trusty'.  The
+For example, on Ubuntu this could be one of 'bionic', 'xenial', or 'trusty'.  The
 instructions will show you how to get this information and then use it to
 configure the right package repo for your system.  This is a one-time
 configuration.  Once its done, you'll be connected to the software distribution

--- a/content/installation/webserver-agent/WebserverAgentConfig.md
+++ b/content/installation/webserver-agent/WebserverAgentConfig.md
@@ -1,0 +1,105 @@
+# Configuration
+
+The items that must be configured are:
+* The communication link between the Webserver Agent and Contrast-Service
+* The communication link between Contrast-Service and TeamServer
+* The NGINX service enabling the Agent to inspect traffic to certain endpoints
+
+# Configuring Contrast-Service
+
+_XXX: config location is moving to
+/etc/contrast/webserver/contrast-security.yaml_
+
+Contrast-Service is controlled by the configuration located at
+`/etc/contrast/contrast_security.yaml`. This is the Contrast Common Config
+format that most agents utilize.  _XXX: link to a general common config
+document_
+
+This file will control how the
+Webserver is represented to TeamServer. The default configuration installed
+with the contrast-service linux package has most necessary items filled in
+however you will need to edit it with your TeamServer location and API key. You
+will also need to configure how you want your agent represented to TeamServer
+
+    server:
+      name: YOUR SERVER NAME
+      path: /
+      type: Proxy
+      environment: development
+
+The other section that needs your specific config in this file is:
+
+    contrast:
+      user_name: YOUR_CONTRAST_USERNAME
+      service_key: YOUR_CONTRAST_SERVICE_KEY
+      api_key: YOUR_CONTRAST_API_KEY
+      url: http://YOUR_TEAMSERVER_LOCATION/Contrast
+
+_XXX: where do I point someone if they are confused as to where to get these
+item?_
+_XXX: give the user a way to test their configuration is working wrt to
+TeamServer?_
+
+# Configuring NGINX with the Webserver Agent.
+
+The Webserver Agent is configured within the NGINX configuration files. These
+are located at `/etc/nginx`.  Configuring NGINX as a reverse proxy or webserver
+is out of scope for this document. Here we'll explain the Webserver Agent
+specific configuration within the NGINX configuration files.
+
+The /etc/nginx.conf should have the webserver agent module added to it, and
+configuration items enabling the webserver agent for certain endpoints in the
+nginx.conf.
+
+
+Example /etc/nginx/nginx.conf:
+    
+    load_module modules/ngx_http_contrast_connector_module.so;
+
+    events {
+      worker_connections 1024;
+    }
+
+    http {
+
+      contrast on;
+      contrast_debug on;
+      contrast_unix_socket "/run/contrast-service.sock";
+
+      error_log logs/error.log debug;
+
+      server {
+        listen 8888;
+        server_name localhost;
+
+        location / {
+          autoindex on;
+          index index.html index.html;
+          contrast_app_name "APP NAME STATIC ENDPOINT";
+        }
+
+        location /app {
+          rewrite /MY_APP/(.*) /$1 break;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_pass http://127.0.0.1:4567;
+          contrast_app_name "APP NAME DYNAMIC ENDPOINT";
+        }
+      }
+    }
+
+This important parts here are the `load_module` directive at the top which is
+loading the webserver agent into nginx and the various `contrast_*` directives.
+The `contrast_*` directives can be placed at the "main", "server", or
+"location" level in an nginx configuration. http://nginx.org/en/docs/beginners_guide.html#conf_structure
+
+The individual directives are explained below:
+
+    contrast:  [on | off] Turns the loaded agent on or off.
+    contrast_debug: [on | off] Turns debug logging on or off.
+    contrast_unix_socket: [string] Specifies the the unix domain socket
+        filepath. This must agree with where Contrast-Service has it
+        configured.
+    contrast_app_name: [string] Application Name as represented in TeamServer.
+
+

--- a/content/installation/webserver-agent/WebserverAgentConfig.md
+++ b/content/installation/webserver-agent/WebserverAgentConfig.md
@@ -1,7 +1,6 @@
 # Configuration
 
 The items that must be configured are:
-* The communication link between the Webserver Agent and Contrast-Service
 * The communication link between Contrast-Service and TeamServer
 * The NGINX service enabling the Agent to inspect traffic to certain endpoints
 

--- a/content/installation/webserver-agent/WebserverAgentConfig.md
+++ b/content/installation/webserver-agent/WebserverAgentConfig.md
@@ -6,19 +6,11 @@ The items that must be configured are:
 
 # Configuring Contrast-Service
 
-_XXX: config location is moving to
-/etc/contrast/webserver/contrast-security.yaml_
+_XXX: config location is moving to /etc/contrast/webserver/contrast-security.yaml_
 
-Contrast-Service is controlled by the configuration located at
-`/etc/contrast/contrast_security.yaml`. This is the Contrast Common Config
-format that most agents utilize.  _XXX: link to a general common config
-document_
+Contrast-Service is controlled by the configuration located at `/etc/contrast/contrast_security.yaml`. This is the Contrast Common Config format that most agents utilize.  _XXX: link to a general common config document_
 
-This file will control how the
-Webserver is represented to TeamServer. The default configuration installed
-with the contrast-service linux package has most necessary items filled in
-however you will need to edit it with your TeamServer location and API key. You
-will also need to configure how you want your agent represented to TeamServer
+This file will control how the Webserver is represented to TeamServer. The default configuration installed with the contrast-service linux package has most necessary items filled in however you will need to edit it with your TeamServer location and API key. You will also need to configure how you want your agent represented to TeamServer
 
     server:
       name: YOUR SERVER NAME
@@ -34,22 +26,14 @@ The other section that needs your specific config in this file is:
       api_key: YOUR_CONTRAST_API_KEY
       url: http://YOUR_TEAMSERVER_LOCATION/Contrast
 
-_XXX: where do I point someone if they are confused as to where to get these
-item?_
-_XXX: give the user a way to test their configuration is working wrt to
-TeamServer?_
+_XXX: where do I point someone if they are confused as to where to get these item?_
+_XXX: give the user a way to test their configuration is working wrt to TeamServer?_
 
 # Configuring NGINX with the Webserver Agent.
 
-The Webserver Agent is configured within the NGINX configuration files. These
-are located at `/etc/nginx`.  Configuring NGINX as a reverse proxy or webserver
-is out of scope for this document. Here we'll explain the Webserver Agent
-specific configuration within the NGINX configuration files.
+The Webserver Agent is configured within the NGINX configuration files. These are located at `/etc/nginx`.  Configuring NGINX as a reverse proxy or webserver is out of scope for this document. Here we'll explain the Webserver Agent specific configuration within the NGINX configuration files.
 
-The /etc/nginx.conf should have the webserver agent module added to it, and
-configuration items enabling the webserver agent for certain endpoints in the
-nginx.conf.
-
+The /etc/nginx.conf should have the webserver agent module added to it, and configuration items enabling the webserver agent for certain endpoints in the nginx.conf.
 
 Example /etc/nginx/nginx.conf:
     
@@ -87,10 +71,7 @@ Example /etc/nginx/nginx.conf:
       }
     }
 
-This important parts here are the `load_module` directive at the top which is
-loading the webserver agent into nginx and the various `contrast_*` directives.
-The `contrast_*` directives can be placed at the "main", "server", or
-"location" level in an nginx configuration. http://nginx.org/en/docs/beginners_guide.html#conf_structure
+This important parts here are the `load_module` directive at the top which is loading the webserver agent into nginx and the various `contrast_*` directives. The `contrast_*` directives can be placed at the "main", "server", or "location" level in an nginx configuration. http://nginx.org/en/docs/beginners_guide.html#conf_structure
 
 The individual directives are explained below:
 

--- a/content/installation/webserver-agent/WebserverAgentInstall.md
+++ b/content/installation/webserver-agent/WebserverAgentInstall.md
@@ -1,51 +1,33 @@
 # Overview
 
-The Contrast Webserver Agent has two methods of installation; installation from
-source or installation from a linux package. Installation from a linux package
-is the easier of the two so use that method unless you really know you need to
-build from source.
+The Contrast Webserver Agent has two methods of installation; installation from source or installation from a linux package. Installation from a linux package is the easier of the two so use that method unless you really know you need to build from source.
 
-At this time, our Webserver Agent targets the 'stable' NGINX server that is officially distributed
-from NGINX. NGINX offers their own linux package repository for obtaining NGINX
-packages and you'll need their official package installed as a dependency for
-our Webserver Agent module that plugs into it.
+At this time, our Webserver Agent targets the 'stable' NGINX server that is officially distributed from NGINX. NGINX offers their own linux package repository for obtaining NGINX packages and you'll need their official package installed as a dependency for our Webserver Agent module that plugs into it. Note if you have a distro's NGINX package installed, you'll need to remove it in favor of the official NGINX distributed package.
 
-Here is their documentation for configuring your system to pull from the
-offical NGINX repos: http://nginx.org/en/linux_packages.html
+Note that NGINX has a 'stable' distribution and  'mainline' distribution and they are configured differently. Choose the configuration for the 'stable'package distribution from their site.
 
-Note that NGINX has a 'stable' distribution and  'mainline' distribution and
-they are configured differently. Choose the configuration for the 'stable' package distribution from their site.
+Here is their documentation for configuring your system to pull from the offical NGINX repos: http://nginx.org/en/linux_packages.html
 
 Once configured, you can move on to installing the package below
 
 # Install from Linux Packages
 
-Provided the Contrast linux package reposistory is configured on your system,
-_XXX: Insert link to contrast package repo setup here
-linux_package_repo/ContrastRepoConfig.md_
-use the following command to install the Webserver Agent:
-
+Provided the Contrast linux package reposistory is configured on your system, _XXX: Insert link to contrast package repo setup here linux_package_repo/ContrastRepoConfig.md_, use the following command to install the Webserver Agent with Contrast-Service:
 Debian/Ubuntu Users:
 
     apt-get update
-    apt-get install contrast-webserver-agent-nginx
+    apt-get install contrast-webserver-agent-nginx contrast-service
 
 RedHat/Centos Users:
 
-    yum install contrast-webserver-agent-nginx
+    yum install contrast-webserver-agent-nginx contrast-service
 
 
-After this stage you are ready to configure the software.  ___XXX: Insert link to
-WebserverAgentConfig.md___.
-
+After this stage you are ready to configure the software.  _XXX: Insert link to WebserverAgentConfig.md_.
 
 # Alternative Installation from Source
 
-The Webserver Agent is constructed as a module that plugs into NGINX. It can be
-compiled statically into NGINX or an an NGINX dynamic module.  The software is
-available at: _XXX: Insert GITHUB link_
+The Webserver Agent is constructed as a module that plugs into NGINX. It can be compiled statically into NGINX or an an NGINX dynamic module.  The software is available at: _XXX: Insert GITHUB link_
 
-And documentation for building from source is within that repo:
-_XXX: Insert GITHUB link to BUILD_FROM_SOURCES.md_
-
+And documentation for building from source is within that repo: _XXX: Insert GITHUB link to BUILD_FROM_SOURCES.md_.
 

--- a/content/installation/webserver-agent/WebserverAgentInstall.md
+++ b/content/installation/webserver-agent/WebserverAgentInstall.md
@@ -21,7 +21,8 @@ Once configured, you can move on to installing the package below
 # Install from Linux Packages
 
 Provided the Contrast linux package reposistory is configured on your system,
-(___Insert link to contrast pacakge repo setup here___)
+_XXX: Insert link to contrast package repo setup here
+linux_package_repo/ContrastRepoConfig.md_
 use the following command to install the Webserver Agent:
 
 Debian/Ubuntu Users:
@@ -34,7 +35,7 @@ RedHat/Centos Users:
     yum install contrast-webserver-agent-nginx
 
 
-After this stage you are ready to configure the software.  ___Insert link to
+After this stage you are ready to configure the software.  ___XXX: Insert link to
 WebserverAgentConfig.md___.
 
 
@@ -42,12 +43,9 @@ WebserverAgentConfig.md___.
 
 The Webserver Agent is constructed as a module that plugs into NGINX. It can be
 compiled statically into NGINX or an an NGINX dynamic module.  The software is
-available at:
-
-    ___Insert GITHUB link___
+available at: _XXX: Insert GITHUB link_
 
 And documentation for building from source is within that repo:
-
-    ___Insert GITHUB link to BUILD_FROM_SOURCES.md___
+_XXX: Insert GITHUB link to BUILD_FROM_SOURCES.md_
 
 

--- a/content/installation/webserver-agent/WebserverAgentInstall.md
+++ b/content/installation/webserver-agent/WebserverAgentInstall.md
@@ -1,0 +1,53 @@
+# Overview
+
+The Contrast Webserver Agent has two methods of installation; installation from
+source or installation from a linux package. Installation from a linux package
+is the easier of the two so use that method unless you really know you need to
+build from source.
+
+At this time, our Webserver Agent targets the 'stable' NGINX server that is officially distributed
+from NGINX. NGINX offers their own linux package repository for obtaining NGINX
+packages and you'll need their official package installed as a dependency for
+our Webserver Agent module that plugs into it.
+
+Here is their documentation for configuring your system to pull from the
+offical NGINX repos: http://nginx.org/en/linux_packages.html
+
+Note that NGINX has a 'stable' distribution and  'mainline' distribution and
+they are configured differently. Choose the configuration for the 'stable' package distribution from their site.
+
+Once configured, you can move on to installing the package below
+
+# Install from Linux Packages
+
+Provided the Contrast linux package reposistory is configured on your system,
+(___Insert link to contrast pacakge repo setup here___)
+use the following command to install the Webserver Agent:
+
+Debian/Ubuntu Users:
+
+    apt-get update
+    apt-get install contrast-webserver-agent-nginx
+
+RedHat/Centos Users:
+
+    yum install contrast-webserver-agent-nginx
+
+
+After this stage you are ready to configure the software.  ___Insert link to
+WebserverAgentConfig.md___.
+
+
+# Alternative Installation from Source
+
+The Webserver Agent is constructed as a module that plugs into NGINX. It can be
+compiled statically into NGINX or an an NGINX dynamic module.  The software is
+available at:
+
+    ___Insert GITHUB link___
+
+And documentation for building from source is within that repo:
+
+    ___Insert GITHUB link to BUILD_FROM_SOURCES.md___
+
+

--- a/content/installation/webserver-agent/WebserverAgentRunning.md
+++ b/content/installation/webserver-agent/WebserverAgentRunning.md
@@ -1,21 +1,18 @@
 # Starting the services
 
-The Webserver Agent ties into the local system's service management tools. For
-recent debian-based systems, this will be systemd.
+The Webserver Agent ties into the local system's service management tools. For recent debian-based systems, this will be systemd.
 
 The Contrast-Service is managed via:
 
-    sudo systemctl start contrast-service
+    sudo systemctl restart contrast-service
     sudo systemctl status contrast-service
 
 The NGINX service via:
 
-    sudo systemctl start nginx
+    sudo systemctl restart nginx
     sudo systemctl status nginx
 
 
-Once those services are running, the Webserver Agent will now protect
-apps through the NGINX server.
+Once those services are running, the Webserver Agent will now protect apps through the NGINX server.
 
-_XXX: do I need any sort of link to TeamServer configuration for enabling
-rules, block(p), etc...???_
+_XXX: do I need any sort of link to TeamServer configuration for enabling rules, block(p), etc...???_

--- a/content/installation/webserver-agent/WebserverAgentRunning.md
+++ b/content/installation/webserver-agent/WebserverAgentRunning.md
@@ -1,0 +1,21 @@
+# Starting the services
+
+The Webserver Agent ties into the local system's service management tools. For
+recent debian-based systems, this will be systemd.
+
+The Contrast-Service is managed via:
+
+    sudo systemctl start contrast-service
+    sudo systemctl status contrast-service
+
+The NGINX service via:
+
+    sudo systemctl start nginx
+    sudo systemctl status nginx
+
+
+Once those services are running, the Webserver Agent will now protect
+apps through the NGINX server.
+
+_XXX: do I need any sort of link to TeamServer configuration for enabling
+rules, block(p), etc...???_


### PR DESCRIPTION
Adds documentation for how to install, configure, and run the webserver agent.  Focuses on install from linux packages.

Related Tickets:
CONTRAST-27468 