### PR TITLE
add remaining certificate options

### DIFF
--- a/content/installation/node/NodeConfig.md
+++ b/content/installation/node/NodeConfig.md
@@ -19,7 +19,11 @@ Parameter                                      | Environment Variable           
 --contrast.proxy.enable [true]                 | CONTRAST\_\_PROXY\_\_ENABLE                    | If `false`, no proxy is being used for communication of data.
 --contrast.proxy.url <url>                     | CONTRAST\_\_PROXY\_\_URL                       | URL of proxy for communicating agent data.
 --contrast.timeout_ms <ms>                     | CONTRAST\_\_TIMEOUT_MS                         | Http timeout value (in ms). Default is **10000**.
+--contrast.certificate.enable [false]          | CONTRAST\_\_CERTIFICATE\_\_ENABLE              | If set to false, the certificate configuration in this section will be ignored.. (default: false)
 --contrast.certificate.ca_file <path>          | CONTRAST\_\_CERTIFICATE\_\_CA_FILE             | When running an Enterprise-on-Premises (EOP) Contrast instance using a self-signed certificate, use this option to provide the relative or absolute path to your CA file.
+--contrast.certificate.cert_file <path>        | CONTRAST\_\_CERTIFICATE\_\_CERT_FILE           | Set the absolute or relative path to the Certificate PEM file for communication with Contrast UI.
+--contrast.certificate.key_file <path>         | CONTRAST\_\_CERTIFICATE\_\_KEY_FILE            | Set the absolute or relative path to the Key PEM file for communication with Contrast UI.
+--contrast.certificate.key_password <pass>     | CONTRAST\_\_CERTIFICATE\_\_KEY_PASSWORD        | If the Key file requires a password, set it here.
 --contrast.certificate.ignore_cert_errors [true] | CONTRAST\_\_CERTIFICATE\_\_IGNORE_CERT_ERRORS  | Allows the agent to communicate data, even if Contrast's cert can't be verified against supplied list of CAs.
 --agent.auto_update [false]                    | AGENT\_\_AUTO_UPDATE                           | If `false`, don't attempt to auto-update the agent. Default is `true`.
 --agent.auto_update_path <path>                | AGENT\_\_AUTO_UPDATE_PATH                      | Directory where the updated agent artifact should be saved before installation. Default is */var/folders/ck/4cpmx4m569j29z7n05dnfb4h0000gp/T*.

--- a/content/installation/node/NodeConfig.md
+++ b/content/installation/node/NodeConfig.md
@@ -19,7 +19,7 @@ Parameter                                      | Environment Variable           
 --contrast.proxy.enable [true]                 | CONTRAST\_\_PROXY\_\_ENABLE                    | If `false`, no proxy is being used for communication of data.
 --contrast.proxy.url <url>                     | CONTRAST\_\_PROXY\_\_URL                       | URL of proxy for communicating agent data.
 --contrast.timeout_ms <ms>                     | CONTRAST\_\_TIMEOUT_MS                         | Http timeout value (in ms). Default is **10000**.
---contrast.certificate.enable [false]          | CONTRAST\_\_CERTIFICATE\_\_ENABLE              | If set to false, the certificate configuration in this section will be ignored.. (default: false)
+--contrast.certificate.enable [false]          | CONTRAST\_\_CERTIFICATE\_\_ENABLE              | If set to false, the certificate configuration in this section will be ignored. (default: false)
 --contrast.certificate.ca_file <path>          | CONTRAST\_\_CERTIFICATE\_\_CA_FILE             | When running an Enterprise-on-Premises (EOP) Contrast instance using a self-signed certificate, use this option to provide the relative or absolute path to your CA file.
 --contrast.certificate.cert_file <path>        | CONTRAST\_\_CERTIFICATE\_\_CERT_FILE           | Set the absolute or relative path to the Certificate PEM file for communication with Contrast UI.
 --contrast.certificate.key_file <path>         | CONTRAST\_\_CERTIFICATE\_\_KEY_FILE            | Set the absolute or relative path to the Key PEM file for communication with Contrast UI.

--- a/content/installation/node/YAML-properties-node.md
+++ b/content/installation/node/YAML-properties-node.md
@@ -47,12 +47,12 @@ Use the properties in this section to connect the Node agent to the Contrast UI.
     * **url**: Set this property as an alternate for `scheme://host:port`. It takes precedence over the other settings, if specified; however, an error will be thrown if both the URL and individual properties are set.
 
   * **certificate**
-    * **enable**: If set to false, the certificate configuration in this section will be ignored.
+    * **enable**: Set to `false` for the agent to ignore the certificate configuration in this section.
     * **ca_file**: Set the absolute or relative path to a CA for communication with Contrast UI using a self-signed certificate.
     * **cert_file**: Set the absolute or relative path to the Certificate PEM file for communication with Contrast UI.
     * **key_file**: Set the absolute or relative path to the Key PEM file for communication with Contrast UI.
-    * **key_password**: If the Key file requires a password, set it here.
-    * **ignore_cert_errors**: When set to `true`, the agent ignores certificate verification errors when the agent communicates with the Contrast UI.
+    * **key_password**: Set the password for the Key file, if required.
+    * **ignore_cert_errors**: Set to `true` for the agent to ignore certificate verification errors when the it communicates with the Contrast UI.
 
 ### Contrast agent properties
 

--- a/content/installation/node/YAML-properties-node.md
+++ b/content/installation/node/YAML-properties-node.md
@@ -40,13 +40,19 @@ Use the properties in this section to connect the Node agent to the Contrast UI.
   * **api_key**: Set the API key needed to communicate with the Contrast UI. **Required.**
   * **service_key**: Set the service key needed to communicate with the Contrast UI. It is used to calculate the Authorization header. **Required.**
   * **user_name**: Set the user name used to communicate with the Contrast UI. It is used to calculate the Authorization header. **Required.**
-  * **ca_file**: Set the absolute or relative path to a CA for communication with Contrast UI using a self-signed certificate. <br> Example: `path/to/ca`
   * **timeout_ms**: Set the default request timeout.
 
   * **proxy**:
     * **enable**: Add a property value to determine if the agent should communicate with the Contrast UI over a proxy. If a property value is not present, the presence of a valid proxy host and port determines enabled status. Value options are `true` or `false`
     * **url**: Set this property as an alternate for `scheme://host:port`. It takes precedence over the other settings, if specified; however, an error will be thrown if both the URL and individual properties are set.
 
+  * **certificate**
+    * **enable**: If set to false, the certificate configuration in this section will be ignored.
+    * **ca_file**: Set the absolute or relative path to a CA for communication with Contrast UI using a self-signed certificate.
+    * **cert_file**: Set the absolute or relative path to the Certificate PEM file for communication with Contrast UI.
+    * **key_file**: Set the absolute or relative path to the Key PEM file for communication with Contrast UI.
+    * **key_password**: If the Key file requires a password, set it here.
+    * **ignore_cert_errors**: When set to `true`, the agent ignores certificate verification errors when the agent communicates with the Contrast UI.
 
 ### Contrast agent properties
 


### PR DESCRIPTION
Add the remaining Node config options for PKI certificates to the documentation.