### PR TITLE
corrected missed items in webserver->proxy rename

### DIFF
--- a/content/installation/linux/LinuxRepoConfig.md
+++ b/content/installation/linux/LinuxRepoConfig.md
@@ -7,7 +7,7 @@ tags: "installation linux package repo distribution"
 
 ## About Linux Package Distribution
 
-Some of Contrast's products, including the [Webserver agent](installation-webserver.html#webserver-install), are distributed through Linux packages. This makes installation and updates very easy and familiar as it utilizes the Linux packaging and distribution system. 
+Some of Contrast's products, including the [Proxy agent](installation-proxy.html#proxy-install), are distributed through Linux packages. This makes installation and updates very easy and familiar as it utilizes the Linux packaging and distribution system. 
 
 To use the Contrast package repository, you must configure your package management system to include the appropriate reference. While most Contrast packages are tied to the specific Linux distribution you're using, some are applicable to any distribution. The following steps for **Ubuntu** and **RedHat/CentOS** users configure both distribution points; once configured, you will have access to all our Linux-packaged products.
 

--- a/content/installation/proxy/ProxyAgentOverview.md
+++ b/content/installation/proxy/ProxyAgentOverview.md
@@ -1,7 +1,7 @@
 <!--
 title: "Contrast Proxy Agent Overview"
 description: "Overview of the Contrast Proxy agent"
-tags: "installation agent webserver nginx overview"
+tags: "installation agent webserver proxy nginx overview"
 -->
 
 The Contrast Proxy agent is application language and framework agnostic. It provides runtime protection by analyzing HTTP request and response data at the web server level rather than the application level. The agent supports Contrast Protect only. 

--- a/content/installation/service/ServiceConfig.md
+++ b/content/installation/service/ServiceConfig.md
@@ -12,7 +12,7 @@ The configuration file is titled *contrast_security.yaml* no matter where it's l
 
 1. The current working directory (e.g., *./contrast_security.yaml*)
 2. An application-specific configuration directory (e.g., *./config/contrast_security.yaml* for Ruby on Rails or *./settings/contrast_security.yaml* for Django)
-3. Within the server's *etc/contrast/webserver* (e.g., */etc/contrast/webserver/contrast_security.yaml*) when being used for the webserver agent
+3. Within the server's *etc/contrast/webserver* (e.g., */etc/contrast/webserver/contrast_security.yaml*) when being used for the Proxy agent
 4. Within the server's *etc/contrast* directory (e.g., */etc/contrast/contrast_security.yaml*)
 5. Within the server's *etc* directory (e.g., */etc/contrast_security.yaml*)
 
@@ -42,7 +42,7 @@ Use the options in this section to allow the agents to find and communicate with
   * **service**:
     * **host**: Set the the hostname or IP address of the Contrast Service to which the Contrast agent should report. <br> Example: `localhost`
     * **port**: Set the the port of the Contrast Service to which the Contrast agent should report. <br> Example: `30555`
-    * **socket**: Set for or the **Webserver agent** only. If this property is defined, the Service is listening on a Unix socket at the defined path. <br> Example: */run/contrast-security.sock*
+    * **socket**: Set for or the **Proxy agent** only. If this property is defined, the Service is listening on a Unix socket at the defined path. <br> Example: */run/contrast-security.sock*
     * **logger**:
       * **path**: Set the location to which the Contrast Service saves log output. If no log file exists at this location, the Service creates one. <br> Example: */opt/Contrast/contrast_service.log* will create a log in the */opt/Contrast* directory.
       * **level**: Set the the log output level. Value options are `ERROR`, `WARN`, `INFO`, and `DEBUG`.

--- a/content/installation/service/ServiceOverview.md
+++ b/content/installation/service/ServiceOverview.md
@@ -4,13 +4,13 @@ description: "Troubleshooting Contrast Service"
 tags: "installation service agent troubleshooting"
 -->
 
-The Contrast Service enables communication between the Contrast UI and one of the multi-process dynamic language agents (e.g., Ruby and Python). <!-- or the Webserver agent. -->
+The Contrast Service enables communication between the Contrast UI and one of the multi-process dynamic language agents (e.g., Ruby and Python). <!-- or the Proxy agent. -->
 
 ## About Contrast Service
 
 The Contrast Service is a stand-alone executable that's used by the [Ruby](installation-ruby.html#ruby-overview) and [Python](installation-python.html#python-overview) agents to communicate with the Contrast UI. It's responsible for passing configuration options to the agent, and to aggregate and send information from the agent back to the Contrast UI. 
 
-<!-- It's also a core component of the NGINX Webserver agent. In a Webserver configuration, the Service listens for requests to the NGINX Webserver and processes requests for potential attacks before allowing the request to proceed to the proxied web application. 
+<!-- It's also a core component of the NGINX Proxy agent. In a Proxy agent configuration, the Service listens for requests to the NGINX Webserver and processes requests for potential attacks before allowing the request to proceed to the proxied web application. 
  -->
 
 <a href="assets/images/Service-arch.png" rel="lightbox" title="Contrast Service architecture"><img class="thumbnail" src="assets/images/Service-arch.png"/></a>
@@ -20,5 +20,5 @@ The Contrast Service is a stand-alone executable that's used by the [Ruby](insta
 
 The Contrast Service is compiled for various supported architectures: Linux 64-bit, Macintosh 64-bit and Windows 64-bit. The Service is packaged with the Ruby and Python agents, and starts automatically when the instrumented application is started. 
 
-<!-- You can also start the Service independently for use with the Webserver agent when installed with the RPM or Debian packages.
+<!-- You can also start the Service independently for use with the Proxy agent when installed with the RPM or Debian packages.
  -->


### PR DESCRIPTION
fixes some missed items in the webserver-> proxy rename
also fixes a broken link on the linux pkg config page because of the rename.