### PR TITLE
fix: reference correct file name

### DIFF
--- a/content/installation/node/NodeInstall.md
+++ b/content/installation/node/NodeInstall.md
@@ -9,7 +9,7 @@ tags: "NodeJS agent installation"
 After downloading from your account, install the agent from your application's root directory as follows:
 
 ``` sh
-npm install node_contrast-#.#.#.tar.gz
+npm install node-contrast-#.#.#.tar.gz
 ```
 This will add the agent to your *node_modules* folder without creating an entry in the dependencies list of your *package.json*.
 


### PR DESCRIPTION
The current `.tar` is named `node-contrast-1.35.2.tar`

Note the dash (`-`) instead of the underscore (`_`). 

It's also like this on `app.contrastsecurity.com`, but I couldn't find anywhere to submit a PR for this. 

Along with an instruction that doesn't work, and isn't in this `docs` repo:
>After installation, the Node.js agent can be run as follows: `node-contrast <app-main>.js`

 
<img width="448" alt="screen shot 2018-12-13 at 10 08 08 am" src="https://user-images.githubusercontent.com/4664374/49947418-35d28d80-febf-11e8-8d60-33aef271285e.png">


Additionally, I get promise warnings, but again, not sure where to report or submit a fix:

```
(node:25311) Warning: a promise was created in a handler at domain.js:409:12 but was not returned from it, see http://goo.gl/rRqMUw
    at Function.Promise.cast(/node_modules/node_contrast/node_modules/bluebird/js/release/promise.js:196:13)
```