### PR TITLE
removing reference to 2.1 and 2.2 as supported ruby versions

### DIFF
--- a/content/installation/ruby/RubySupportedTechnologies.md
+++ b/content/installation/ruby/RubySupportedTechnologies.md
@@ -4,7 +4,7 @@ description: "List of supported technologies"
 tags: "installation Ruby on Rails agent frameworks support troubleshooting gem"
 -->
 
-The Ruby agent supports Ruby language versions 2.1.x through 2.5.x. Framework support is currently for Ruby on Rails versions 3.x and above as well as Sinatra 2.x and above. The Ruby agent is a standard Rack middleware; consequently, it may work in other Rack-based web frameworks like Grape and Padrino. 
+The Ruby agent supports Ruby language versions 2.3.x through 2.5.x. Framework support is currently for Ruby on Rails versions 3.x and above as well as Sinatra 2.x and above. The Ruby agent is a standard Rack middleware; consequently, it may work in other Rack-based web frameworks like Grape and Padrino. 
 
 ## Database Support
 


### PR DESCRIPTION
Removing 2.1 and 2.2 support. We'll add 2.6 for the April release