### PR TITLE
Remove 1 App - 1 JVM release note

### DIFF
--- a/content/release/ReleaseNotes359.md
+++ b/content/release/ReleaseNotes359.md
@@ -33,13 +33,7 @@ Our gift to you: completely revamped grids for all your applications, servers an
 
 ### Java summary 
 
-The Java team expanded coverage of the Protect Expression Language Injection rule to also cover RichFaces CVEs, including CVE-2018-14667. We improved the accuracy of a Regular Expression DoS rule as well as the reliability of a Protect CSRF rule. We also fixed an issue where the agent could fail to enable Assess rules if all rules were enabled.
-
-#### One application per JVM 
-
-In an upcoming release, the Java agent will move to a mandatory one application per JVM reporting model. This change provides more consistency across agent configuration and reporting across technology stacks. It also better reflects current best practices in web application packaging and deployment, targeting cloud infrastructures with dynamically deployable and scalable application clusters. The new model also eliminates the sometimes unreliable heuristics (based request context path) currently used to partition requests to specific applications, and will provide better reporting as a result.
-
-In preparation for the new model, application naming properties `contrast.override.appname` and `contrast.standalone.appname` are being deprecated and replaced by `application.name`. As of a future release, the deprecated properties will no longer be honored. [Java System Properties](installation-javaconfig.html#system) will be updated to reflect each stage of these changes. 
+The Java team expanded coverage of the Protect Expression Language Injection rule to also cover RichFaces CVEs, including CVE-2018-14667. We improved the accuracy of a Regular Expression DoS rule as well as the reliability of a Protect CSRF rule. We also fixed an issue where the agent could fail to enable Assess rules if all rules were enabled. 
 
 ### .NET summary 
 


### PR DESCRIPTION
As the move to 1 App - 1 JVM has been pushed back for the time being, this release note should be removed to avoid any confusion.