### PR TITLE
update python config file locations

### DIFF
--- a/content/installation/python/PythonConfig.md
+++ b/content/installation/python/PythonConfig.md
@@ -8,15 +8,14 @@ The Python agent and Contrast Service use a YAML file to alter the agent behavio
 
 ## Order of Precedence
 
-The configuration file is always called *contrast_security.yaml* or *contrast_security.yml* no matter where it's located. The Python agent loads the configuration YAML from the following paths in order of precedence:
+The configuration file is named *contrast_security.yaml* or *contrast_security.yml* no matter where it's located. The Python agent loads the configuration YAML from the following paths in order of precedence:
 
-1. Any path saved in an environment variable named `CONTRAST_CONFIG_PATH`
+1. Any path saved in the environment variable `CONTRAST_CONFIG_PATH`
 2. The settings directory within the current directory (e.g., *./settings/contrast_security.yaml*)
 3. The current working directory (e.g., *./contrast_security.yaml*)
 4. Within the server's *etc/contrast/python* directory (e.g., */etc/contrast/python/contrast_security.yaml*)
 5. Within the server's *etc/contrast* directory (e.g., */etc/contrast/contrast_security.yaml*)
 
-   
 The agent and service may share a common configuration file, but only some options and sections are applicable to each process.
 
 ## Configuration Options

--- a/content/installation/python/PythonConfig.md
+++ b/content/installation/python/PythonConfig.md
@@ -8,12 +8,15 @@ The Python agent and Contrast Service use a YAML file to alter the agent behavio
 
 ## Order of Precedence
 
-The configuration file is always called *contrast_security.yaml* no matter where it's located. The Python agent loads the configuration YAML from the following paths in order of precedence:
+The configuration file is always called *contrast_security.yaml* or *contrast_security.yml* no matter where it's located. The Python agent loads the configuration YAML from the following paths in order of precedence:
 
-1. The current working directory (e.g., *./contrast_security.yaml*)
-2. Within the server's *etc/contrast* directory (e.g., */etc/contrast/contrast_security.yaml*)
-3. Within the server's *etc* directory (e.g., */etc/contrast_security.yaml*)
+1. Any path saved in an environment variable named `CONTRAST_CONFIG_PATH`
+2. The settings directory within the current directory (e.g., *./settings/contrast_security.yaml*)
+3. The current working directory (e.g., *./contrast_security.yaml*)
+4. Within the server's *etc/contrast/python* directory (e.g., */etc/contrast/python/contrast_security.yaml*)
+5. Within the server's *etc/contrast* directory (e.g., */etc/contrast/contrast_security.yaml*)
 
+   
 The agent and service may share a common configuration file, but only some options and sections are applicable to each process.
 
 ## Configuration Options


### PR DESCRIPTION
Updating python docs indicating the new places the agent will look for the contrast config yml file.
 Related python agent PR https://bitbucket.org/contrastsecurity/python-agent/pull-requests/357/update-readme-with-config-locations/diff