### PR TITLE
CONTRAST-31192 update .NET Framework docs 

### DIFF
--- a/content/installation/net/install/NetInstallation.md
+++ b/content/installation/net/install/NetInstallation.md
@@ -27,7 +27,7 @@ You can fully configure the agent using the *contrast_security.yaml* file. See t
     enable: false
  ```
 
-**Note:** The *contrast_security.yaml* file is copied to the agent's data directory by the installer (*C:\ProgramData\Contrast\dotnet\contrast_security.yaml* by default.) The installer does **not** copy the YAML file if it already exists at the destination.
+> **Note:** The *contrast_security.yaml* file is copied to the agent's data directory by the installer (*C:\ProgramData\Contrast\dotnet\contrast_security.yaml* by default). The installer does **not** copy the YAML file if it already exists at the destination.
 
 ## Silent Installation
 

--- a/content/installation/net/install/NetInstallation.md
+++ b/content/installation/net/install/NetInstallation.md
@@ -50,8 +50,6 @@ Many users are curious about the changes made by the .NET agent and the impacts 
 - Places the agent’s files on a disk in the specified install location (e.g., *C:\Program Files\Contrast\dotnet*). This includes several dynamic link libraries (DLLs) and executables, such as the background Windows service that drives agent behavior. 
 - Creates the specified data directory for the agent that's primarily used to store agent log files and configuration (e.g., *C:\ProgramData\Contrast\dotnet*). 
 - Registers the agent’s background Window service with the operating system.
-- Reads the *DotnetAgentSettings.ini* file to customize the agent’s configuration file with details necessary to communicate with the Contrast application (e.g., API key).
-- Registers several agent assemblies with the .NET global assembly cache so they can be loaded by instrumented applications.
 - Starts the agent’s background Windows service and Tray (UI) application. This service has a number of responsibilities: 
   - Preparing the environment for instrumentation by registering the agent’s profiler component with IIS through environment variables, and restarting IIS. This causes the CLR to load the agent’s profiler, which is responsible for instrumenting analyzed applications. 
   - Communication with the Contrast UI.

--- a/content/installation/net/install/System-requirements-net.md
+++ b/content/installation/net/install/System-requirements-net.md
@@ -30,4 +30,4 @@ Before installing the .NET agent, confirm that you can meet the following requir
 >
 > * The .NET agent roughly doubles the RAM requirements of analyzed applications. Applications should use less than half of the available memory when the .NET agent is not installed. 
 >
-> * The .NET agent uses the CLR Profiling API to perform data and code flow analysis - detect SQL-injection, XSS, weak cryptography, etc. - as well as to detect libraries and technologies used by analyzed applications. The Contrast agent can now exist alongside other .NET Profiler agents, such as performance or APM tools with the `ProfilerChainingEnabled` [configuration setting](installation-netconfig.html#overview) enabled.
+> * The .NET agent uses the CLR Profiling API to perform data and code flow analysis - detect SQL-injection, XSS, weak cryptography, etc. - as well as to detect libraries and technologies used by analyzed applications. The Contrast agent can now exist alongside other .NET Profiler agents, such as performance or APM tools with the `contrast.agent.dotnet.enable_chaining` [configuration setting](installation-netconfig.html#overview) enabled.

--- a/content/installation/net/install/System-requirements-net.md
+++ b/content/installation/net/install/System-requirements-net.md
@@ -30,4 +30,4 @@ Before installing the .NET agent, confirm that you can meet the following requir
 >
 > * The .NET agent roughly doubles the RAM requirements of analyzed applications. Applications should use less than half of the available memory when the .NET agent is not installed. 
 >
-> * The .NET agent uses the CLR Profiling API to perform data and code flow analysis - detect SQL-injection, XSS, weak cryptography, etc. - as well as to detect libraries and technologies used by analyzed applications. The Contrast agent can now exist alongside other .NET Profiler agents, such as performance or APM tools with the `contrast.agent.dotnet.enable_chaining` [configuration setting](installation-netconfig.html#overview) enabled.
+> * The .NET agent uses the CLR Profiling API to perform data and code flow analysis - detect SQL-injection, XSS, weak cryptography, etc. - as well as to detect libraries and technologies used by analyzed applications. The Contrast agent can now exist alongside other .NET Profiler agents, such as performance or APM tools with the `agent.dotnet.enable_chaining` [configuration setting](installation-netconfig.html#overview) enabled.

--- a/content/installation/net/usage/GeneralUsage.md
+++ b/content/installation/net/usage/GeneralUsage.md
@@ -31,11 +31,11 @@ To start the agent, and consequently enable analysis, complete either of the the
 #### Option one
 
 * Go to **Windows Start**, and select **Services**.
-* Right click on **Contrast .NET Main Service**, and select **Stop**
+* Right click on **Contrast .NET Main Service**, and select **Start**
 
 #### Option two 
 
-* From an administrator command prompt, use `net stop DotnetAgentSvc`.
+* From an administrator command prompt, use `net start DotnetAgentSvc`.
 
 >**Note:** By default, the Contrast .NET Main Service starts automatically when Windows starts as well as when the agent is first installed.
 
@@ -46,11 +46,11 @@ To stop the agent, and consequently disable Contrast instrumentation and analysi
 #### Option one
 
 * Go to **Start** and select **Services**.  
-* Right click on **Contrast .NET Main Service** and select **Start**. 
+* Right click on **Contrast .NET Main Service** and select **Stop**. 
 
 #### Option two
 
-* From an administrator command prompt, use `net start DotnetAgentSvc`.
+* From an administrator command prompt, use `net stop DotnetAgentSvc`.
 
 ## .NET Contrast Tray          
 

--- a/content/installation/net/usage/NetApplicationPoolFiltering.md
+++ b/content/installation/net/usage/NetApplicationPoolFiltering.md
@@ -14,7 +14,7 @@ In either case, you can use the .NET agent's application pool filtering feature.
 
 ## Application Pool Filtering 
 
-Web applications hosted on IIS run on application pools. If you need to disable the .NET agent for specific application pools on an instance of IIS, configure a `ProcessBlacklist`. When an application pool is blacklisted, the agent won't attach to any applications using that application pool, and there should be no performance impact for those applications.
+Web applications hosted on IIS run on application pools. If you need to disable the .NET agent for specific application pools on an instance of IIS, configure a `agent.dotnet.app_pool_blacklist`. When an application pool is blacklisted, the agent won't attach to any applications using that application pool, and there should be no performance impact for those applications.
 
 Whitelisting and blacklisting are based on the application pool *name*. Application pool blacklists and whitelists also accept `*` as a variable-length wildcard. ("AppPool*" will match "AppPool1", "AppPool_arb", etc.)
 
@@ -58,22 +58,26 @@ Use **Contrast .NET Logs**:
 
 ## Blacklist an Application Pool
 
-To disable the agent for a specific application, populate `ProcessBlacklist` with the appropriate application pool in *C:\Program Files\Contrast\dotnet\DotnetAgentService.exe.config*:
+To disable the agent for a specific application, populate `agent.dotnet.app_pool_blacklist` with the appropriate application pool in *C:\ProgramData\Contrast\dotnet\contrast_security.yaml*:
 
 ```
 <!--Comma-separated list of application pools ignored by Contrast-->
-<add key="ProcessBlacklist" value=""/>
+agent:
+  dotnet:
+    app_pool_blacklist: ExampleAppPoolName
 ```
 
 ## Whitelist an Application Pool 
 
-If you need to only enable the agent for specific applications hosted by IIS, configure a `ProcessWhitelist` to only analyze certain application pools. If an application pool is whitelisted, the agent analyzes the matching pools. There should be no performance impact for any other applications.
+If you need to only enable the agent for specific applications hosted by IIS, configure `agent.dotnet.app_pool_whitelist` to only analyze certain application pools. If an application pool is whitelisted, the agent analyzes the matching pools. There should be no performance impact for any other applications.
 
-To enable the agent for only specific application pools, populate `ProcessWhitelist` with the appropriate application pool in *C:\Program Files\Contrast\dotnet\DotnetAgentService.exe.config*:
+To enable the agent for only specific application pools, populate `agent.dotnet.app_pool_whitelist` with the appropriate application pool in *C:\ProgramData\Contrast\dotnet\contrast_security.yaml*:
 
 ```
 <!--Comma-separated list of application pools exclusively profiled by Contrast-->
-<add key="ProcessWhitelist" value=""/>
+agent:
+  dotnet:
+    app_pool_whitelist: ExampleAppPoolName
 ```
 
 For more information on the standard configuration for the agent, see the [Configuration Overview](installation-netconfig.html#overview).

--- a/content/installation/net/usage/NetApplicationPoolFiltering.md
+++ b/content/installation/net/usage/NetApplicationPoolFiltering.md
@@ -61,7 +61,7 @@ Use **Contrast .NET Logs**:
 To disable the agent for a specific application, populate `agent.dotnet.app_pool_blacklist` with the appropriate application pool in *C:\ProgramData\Contrast\dotnet\contrast_security.yaml*:
 
 ```
-<!--Comma-separated list of application pools ignored by Contrast-->
+# Comma-separated list of application pools ignored by Contrast
 agent:
   dotnet:
     app_pool_blacklist: ExampleAppPoolName
@@ -74,7 +74,7 @@ If you need to only enable the agent for specific applications hosted by IIS, co
 To enable the agent for only specific application pools, populate `agent.dotnet.app_pool_whitelist` with the appropriate application pool in *C:\ProgramData\Contrast\dotnet\contrast_security.yaml*:
 
 ```
-<!--Comma-separated list of application pools exclusively profiled by Contrast-->
+# Comma-separated list of application pools exclusively profiled by Contrast
 agent:
   dotnet:
     app_pool_whitelist: ExampleAppPoolName

--- a/content/troubleshooting/net/ConnectingToTeamServer.md
+++ b/content/troubleshooting/net/ConnectingToTeamServer.md
@@ -15,11 +15,11 @@ tags: "troubleshoot Contrast interface agent installation .NET"
 
 ## Solution
 
-* Open the .NET agent's configuration file, *DotnetAgentService.exe.config*, which is located in the agent's installation directory (i.e., *C:/Program Files/Contrast .NET*).
+* Open the .NET agent's configuration file, *contrast_security.yaml*, which is located in the agent's data directory (i.e., *C:/ProgramData/Contrast/dotnet*).
 
-* Verify that the `TeamServerUrl` value (e.g., [https://app.contrastsecurity.com/Contrast](https://app.contrastsecurity.com/Contrast)) can be reached from a normal web browser on the server. If the URL can't be reached, you should review the network path and related settings between the server and the Contrast application.
+* Verify that the `api.url` value (e.g., [https://app.contrastsecurity.com/Contrast](https://app.contrastsecurity.com/Contrast)) can be reached from a normal web browser on the server. If the URL can't be reached, you should review the network path and related settings between the server and the Contrast application.
 
-* Verify proxy settings. If a normal web browser can connect to Contrast but the agent can't, the agent might be missing the proxy settings required by your network environment. You can configure a proxy using the `ProxyAuth`, `ProxyUser`, `ProxyPass` and `ProxyAddress` values in the [configuration](installation-netconfig.html) file.
+* Verify proxy settings. If a normal web browser can connect to Contrast but the agent can't, the agent might be missing the proxy settings required by your network environment. You can configure a proxy using the `api.proxy.url`, `api.proxy.user`, `api.proxy.pass` and `api.proxy.auth_type` values in the [configuration](installation-netconfig.html) file.
 
-* Verify that the API key is correct. If the above settings are correct, the API key used by your organization might have changed. Follow these [directions](admin-systemsettings.html#apikey) to view your current API Key.
+* Verify that the API key (`api.api_key`) is correct. If the above settings are correct, the API key used by your organization might have changed. Follow these [directions](admin-systemsettings.html#apikey) to view your current API Key.
 

--- a/content/troubleshooting/net/GettingNetAgentLogs.md
+++ b/content/troubleshooting/net/GettingNetAgentLogs.md
@@ -8,7 +8,7 @@ In rare scenarios, bad instrumentation causes a web server process to crash or a
 
 ## Agent Logs Directory
 
-The .NET agent logs information to the *Contrast\dotnet\LOGS* directory within *C:\ProgramData\Contrast\dotnet\LOGS*, the Windows 2008/2012 *ProgramData* directory. Depending on the setup of the Windows profile and folder view settings, the directories may be hidden. If so, paste the paths into the Windows Explorer location; you may need to replace the drive letter *C* with *D*.
+The .NET agent logs information to the *LOGS* directory within *C:\ProgramData\Contrast\dotnet\*, the Windows 2008/2012/2016 *ProgramData* directory. Depending on the setup of the Windows profile and folder view settings, the directories may be hidden. If so, paste the paths into the Windows Explorer location; you may need to replace the drive letter *C* with *D*.
 
 You can change which information is logged by changing the logging level in the [.NET agent configuration](installation-netconfig.html).
 
@@ -68,10 +68,16 @@ Complete the following steps to gather information to send to Contrast.
   * [Stop the .NET agent service](http://127.0.0.1:9000/installation-netusage.html#usage).
   * Enable additional logging. 
      * ** Start > Notepad > Right click > Run as Administrator**
-     * ** File > Open >** *C:\Program Files\Contrast\dotnet\DotnetAgentService.exe.config*
-     * Change `ShouldLogMethodSignatures` to `true`.
-     * Uncomment the entry for `LogLevel`. 
-     * Check that the specified `LogLevel` value is `trace`.
+     * ** File > Open >** *C:\ProgramData\Contrast\dotnet\contrast_security.yaml*
+     * Add the following configuration to the yaml file to enable verbose logging and logging of every method JIT-compiled by the CLR:
+```
+agent:
+  dotnet:
+    logger:
+      level: trace
+    secret:
+      log_method_sigs: true
+```
   * Start the .NET agent service.
   * Exercise the application to reproduce the crash.
 

--- a/content/troubleshooting/net/GettingNetAgentLogs.md
+++ b/content/troubleshooting/net/GettingNetAgentLogs.md
@@ -8,7 +8,7 @@ In rare scenarios, bad instrumentation causes a web server process to crash or a
 
 ## Agent Logs Directory
 
-The .NET agent logs information to the *LOGS* directory within *C:\ProgramData\Contrast\dotnet\*, the Windows 2008/2012/2016 *ProgramData* directory. Depending on the setup of the Windows profile and folder view settings, the directories may be hidden. If so, paste the paths into the Windows Explorer location; you may need to replace the drive letter *C* with *D*.
+The .NET agent logs information to the *LOGS* directory within the data directory specified at install time. By default, LOGS are written to *%ProgramData%\Contrast\dotnet\LOGS*, within the Windows *ProgramData* directory. Depending on the setup of the Windows profile and folder view settings, the directories may be hidden. If so, paste the path into the Windows Explorer location.
 
 You can change which information is logged by changing the logging level in the [.NET agent configuration](installation-netconfig.html).
 
@@ -67,7 +67,7 @@ Complete the following steps to gather information to send to Contrast.
   * Install the latest .NET agent.
   * [Stop the .NET agent service](http://127.0.0.1:9000/installation-netusage.html#usage).
   * Enable additional logging. 
-     * ** Start > Notepad > Right click > Run as Administrator**
+     * ** Start > Notepad
      * ** File > Open >** *C:\ProgramData\Contrast\dotnet\contrast_security.yaml*
      * Add the following configuration to the yaml file to enable verbose logging and logging of every method JIT-compiled by the CLR:
 ```

--- a/content/troubleshooting/net/UsingNetWithSSLCertificate.md
+++ b/content/troubleshooting/net/UsingNetWithSSLCertificate.md
@@ -38,17 +38,12 @@ Contrast only recommends that you use these solutions for testing purposes in a 
 
 Alternatively, you can configure the agent to trust **any** certificate. You should only use this configuration for testing purposes or in trusted environments.
 
-* In a text editor, open *-%SYSTEMDRIVE%\Program Files\Contrast\dotnet\DotnetAgentService.exe.config*. 
-* In the **appSettings** section, add the `TeamServerValidateCert` tag. 
+* In a text editor, open *-%SYSTEMDRIVE%\ProgramData\Contrast\dotnet\contrast_security.yaml*. 
+* Set `api.certificate.ignore_cert_errors` to `false`: 
 
 > **Example:** 
  ```
- <?xml version="1.0"?>
- <configuration>
-  <appSettings>
-  <add key="TeamServerUrl" value="*****************"/>
-  <add key="TeamServerUserName" value="*******************"/>
-  <add key="TeamServerApiKey" value="**************"/>
-  <add key="TeamServerServiceKey" value="************"/>
-  <add key="TeamServerValidateCert" value="false"/>
+api:
+  certificate:
+    ignore_cert_errors: false
  ```

--- a/content/user/apps/AddingAnApplication.md
+++ b/content/user/apps/AddingAnApplication.md
@@ -55,9 +55,22 @@ For **Java**, add the system property `contrast.group` to make your new startup 
 
 For **.Net**, you can configure group access at the application or server level. 
 
-* To add the individual application to the group, add the `Contrast.AppGroup` property to the `appSettings` group in the application's *web.config* file. 
-* To add all applications on a server to a group, add `Contrast.AppGroup` to the *DotnetAgentService.exe.config* file for the agent server.   
+* To add the individual application to the group, add the `contrast.application.group` or `Contrast.AppGroup` property to the `appSettings` group in the application's *web.config* file. 
+* To add all applications on a server to a group, add `application.group` to the *contrast_security.yaml* file for the agent server.   
 
+> **Example:**
+ ``` web.config
+ <appSettings>
+   <add key="contrast.application.group" value="" />
+ </appSettings>
+ ```
+ 
+ > **Example:**
+ ``` yaml
+ application:
+   group: insertGroupNameHere
+ ```
+ 
 For **Node.js**, you can choose from two configuration methods. 
 
 * You can add `"appGroup":"groupname"` to the *contrast_security.yaml* file. 

--- a/content/user/apps/AddingAnApplication.md
+++ b/content/user/apps/AddingAnApplication.md
@@ -53,18 +53,19 @@ For **Java**, add the system property `contrast.group` to make your new startup 
  -Dcontrast.group="Contrast Testing" -javaagent:/path/to/contrast.jar
  ```
 
-For **.Net**, you can configure group access at the application or server level. 
+For **.NET**, you can configure group access at the application or server level. 
 
 * To add the individual application to the group, add the `contrast.application.group` or `Contrast.AppGroup` property to the `appSettings` group in the application's *web.config* file. 
-* To add all applications on a server to a group, add `application.group` to the *contrast_security.yaml* file for the agent server.   
 
-> **Example:**
+ > **Example:**
  ``` web.config
  <appSettings>
    <add key="contrast.application.group" value="insertGroupNameHere" />
  </appSettings>
  ```
- 
+
+* To add all applications on a server to a group, add `application.group` to the *contrast_security.yaml* file for the agent server.   
+
  > **Example:**
  ``` yaml
  application:

--- a/content/user/apps/AddingAnApplication.md
+++ b/content/user/apps/AddingAnApplication.md
@@ -61,7 +61,7 @@ For **.Net**, you can configure group access at the application or server level.
 > **Example:**
  ``` web.config
  <appSettings>
-   <add key="contrast.application.group" value="" />
+   <add key="contrast.application.group" value="insertGroupNameHere" />
  </appSettings>
  ```
  


### PR DESCRIPTION
- Change profiler chaining note to use the common config key rather than the legacy key
- Remove information changes that are no longer made by the .NET Framework installer
- Replace legacy configuration examples with common config examples throughout .NET Framework docs