### PR TITLE
Update .NET agent config with common config options

### DIFF
--- a/content/installation/net/configuration/NetAgentConfiguration.md
+++ b/content/installation/net/configuration/NetAgentConfiguration.md
@@ -6,6 +6,8 @@ tags: "installation microsoft agent configuration settings .Net"
 
 The Contrast configuration file *DotnetAgentService.exe.config* contains several settings that you can modify to change the behavior of the .NET agent for Windows. In all cases, configuration values in the agent configuration file will override any configuration values that have the same name specified in the Contrast interface (e.g., logging level, sampling and stack trace configuration).
 
+> **Note:** These configuration values are considered "legacy" configuration options. New configuration values will only be supported via yaml-style configuration. Users are encouraged to migrate to yaml-based configuration.
+
 ## General
 
 | Parameter                | Description                              | Version |

--- a/content/installation/net/configuration/NetAgentConfiguration.md
+++ b/content/installation/net/configuration/NetAgentConfiguration.md
@@ -4,9 +4,9 @@ description: "Guide to configuring .NET agent settings"
 tags: "installation microsoft agent configuration settings .Net"
 -->
 
-The Contrast configuration file *DotnetAgentService.exe.config* contains several settings that you can modify to change the behavior of the .NET agent for Windows. In all cases, configuration values in the agent configuration file will override any configuration values that have the same name specified in the Contrast interface (e.g., logging level, sampling and stack trace configuration).
+The Contrast configuration file *DotnetAgentService.exe.config* contains several settings that you can modify to change the behavior of the .NET agent for Windows. In all cases, configuration values in the agent configuration file will override any configuration values that have the same name specified in the Contrast UI (e.g., logging level, sampling and stack trace configuration).
 
-> **Note:** These configuration values are considered "legacy" configuration options. New configuration values will only be supported via yaml-style configuration. Users are encouraged to migrate to yaml-based configuration.
+> **Note:** These configuration values are considered legacy configuration options. New configuration values will only be supported via YAML-based configuration. All users are encouraged to migrate to [YAML configuration properties](installation-netconfig.html#net-yaml).
 
 ## General
 

--- a/content/installation/net/configuration/SettingDisplayNameForApplications.md
+++ b/content/installation/net/configuration/SettingDisplayNameForApplications.md
@@ -6,22 +6,24 @@ tags: "configuration microsoft IIS application name agent installation .NET vers
 
 Users can customize several pieces of information that are specific to each application by adding entries to the application's *web.config* file. In order for the agent to pick up customized application settings, you must place these settings in the application *web.config* file's root configuration *appSettings* section. 
 
-| Parameter           | Description | Version |
-|---------------------|-------------|---------|
-| Contrast.AppName    | Controls the application name sent to the Contrast interface for this application. The `Contrast.AppName` setting should be present on each server where the application is to be analyzed. Otherwise the applications could have different display names (see below) and be considered as different applications by the Contrast application.        | 3.1.3+  |
-| Contrast.AppVersion | Controls the application version tag sent to Contrast. | 3.3.6+  |
-| Contrast.AppGroup   | Specifies the group to which this application will be added in the Contrast interface, if this application isn't  already a member of a group.        | 3.4.5+ |
-| Contrast.AppTags    | Controls free-form tags sent to Contrast for the application; you can use tags to search for specific applications in the Contrast interface.        | 4.8.20+ |
-| Contrast.LibraryTags   | Controls free-form tags sent to Contrast for the application's libraries; you can use tags to search for specific libraries in the Contrast interface.        | 4.8.20+ |
-| Contrast.FindingTags   | Controls free-form tags sent to Contrast for the application's vulnerabilities; you can use tags to search for specific vulnerabilities in the Contrast interface.        | 4.8.20+ |
+> **Note:** The "Contrast.CamelCase"-style configuration options are considered "legacy". New configuration values will follow the yaml-style naming convention. Users are encouraged to migrate to yaml-based names in their applications' *web.config* files.
+
+| Option                       | Legacy Option        | Description | Version |
+|------------------------------|----------------------|-------------|---------|
+| contrast.application.name    | Contrast.AppName     | Controls the application name sent to the Contrast interface for this application. The `Contrast.AppName` setting should be present on each server where the application is to be analyzed. Otherwise the applications could have different display names (see below) and be considered as different applications by the Contrast application.        | 3.1.3+  |
+| contrast.application.version | Contrast.AppVersion  | Controls the application version tag sent to Contrast. | 3.3.6+  |
+| contrast.application.group   | Contrast.AppGroup    | Specifies the group to which this application will be added in the Contrast interface, if this application isn't  already a member of a group.        | 3.4.5+ |
+| contrast.application.tags    | Contrast.AppTags     | Controls free-form tags sent to Contrast for the application; you can use tags to search for specific applications in the Contrast interface.        | 4.8.20+ |
+| contrast.inventory.tags      | Contrast.LibraryTags | Controls free-form tags sent to Contrast for the application's libraries; you can use tags to search for specific libraries in the Contrast interface.        | 4.8.20+ |
+| contrast.assess.tags         | Contrast.FindingTags | Controls free-form tags sent to Contrast for the application's vulnerabilities; you can use tags to search for specific vulnerabilities in the Contrast interface.        | 4.8.20+ |
 
 
 > **Example:**
  ```
  <configuration>
    <appSettings>
-     <add key="Contrast.AppName" value="MyWebAppName" />
-     <add key="Contrast.AppVersion" value="1.2.3" />
+     <add key="contrast.application.name" value="MyWebAppName" />
+     <add key="contrast.application.version" value="1.2.3" />
    </appSettings>
    <system.web>
      ...

--- a/content/installation/net/configuration/SettingDisplayNameForApplications.md
+++ b/content/installation/net/configuration/SettingDisplayNameForApplications.md
@@ -6,16 +6,16 @@ tags: "configuration microsoft IIS application name agent installation .NET vers
 
 Users can customize several pieces of information that are specific to each application by adding entries to the application's *web.config* file. In order for the agent to pick up customized application settings, you must place these settings in the application *web.config* file's root configuration *appSettings* section. 
 
-> **Note:** The "Contrast.CamelCase"-style configuration options are considered "legacy". New configuration values will follow the yaml-style naming convention. Users are encouraged to migrate to yaml-based names in their applications' *web.config* files.
+> **Note:** The "Contrast.CamelCase"-style configuration options are considered legacy options. New configuration values will follow the YAML-style naming convention. All users are encouraged to migrate to [YAML-based property names](installation-netconfig.html#net-yaml) in their applications' *web.config* files.
 
 | Option                       | Legacy Option        | Description | Version |
 |------------------------------|----------------------|-------------|---------|
-| contrast.application.name    | Contrast.AppName     | Controls the application name sent to the Contrast interface for this application. The `Contrast.AppName` setting should be present on each server where the application is to be analyzed. Otherwise the applications could have different display names (see below) and be considered as different applications by the Contrast application.        | 3.1.3+  |
+| contrast.application.name    | Contrast.AppName     | Controls the application name sent to the Contrast UI for this application. The `Contrast.AppName` setting should be present on each server where the application is to be analyzed. If it isn't present, the applications could have different display names and be considered as different applications by the Contrast application. See the **Absent Configuration Setting** section below for more details.      | 3.1.3+  |
 | contrast.application.version | Contrast.AppVersion  | Controls the application version tag sent to Contrast. | 3.3.6+  |
-| contrast.application.group   | Contrast.AppGroup    | Specifies the group to which this application will be added in the Contrast interface, if this application isn't  already a member of a group.        | 3.4.5+ |
-| contrast.application.tags    | Contrast.AppTags     | Controls free-form tags sent to Contrast for the application; you can use tags to search for specific applications in the Contrast interface.        | 4.8.20+ |
-| contrast.inventory.tags      | Contrast.LibraryTags | Controls free-form tags sent to Contrast for the application's libraries; you can use tags to search for specific libraries in the Contrast interface.        | 4.8.20+ |
-| contrast.assess.tags         | Contrast.FindingTags | Controls free-form tags sent to Contrast for the application's vulnerabilities; you can use tags to search for specific vulnerabilities in the Contrast interface.        | 4.8.20+ |
+| contrast.application.group   | Contrast.AppGroup    | Specifies the group to which this application will be added in the Contrast UI, if this application isn't already a member of a group.        | 3.4.5+ |
+| contrast.application.tags    | Contrast.AppTags     | Controls free-form tags sent to Contrast for the application. You can use tags to search for specific applications in the Contrast UI.        | 4.8.20+ |
+| contrast.inventory.tags      | Contrast.LibraryTags | Controls free-form tags sent to Contrast for the application's libraries. You can use tags to search for specific libraries in the Contrast UI.        | 4.8.20+ |
+| contrast.assess.tags         | Contrast.FindingTags | Controls free-form tags sent to Contrast for the application's vulnerabilities. You can use tags to search for specific vulnerabilities in the Contrast UI.        | 4.8.20+ |
 
 
 > **Example:**

--- a/content/installation/net/configuration/YAML-properties-net.md
+++ b/content/installation/net/configuration/YAML-properties-net.md
@@ -15,8 +15,8 @@ Configuration values use the following order of precedence:
 1. Corporate rule (e.g., expired license overrides `assess.enable`)
 2. Specific environmental variable
 3. Generic environment variable value
-4. Application-specific configuration file value (i.e. web.config)
-5. User configuration file value (i.e. contrast_security.yaml)
+4. Application-specific configuration file value (i.e. *web.config*)
+5. User configuration file value (i.e. *contrast_security.yaml*)
 6. Contrast UI value
 7. Default value
 
@@ -27,17 +27,17 @@ The *contrast_security.yaml* file should be placed on the file system using one 
 * Specify the path to the YAML file with the environment variable `CONTRAST_CONFIG_PATH`.
 * Place the *contrast_security.yaml* file in the data directory specified during agent install. (The default location is * %ProgramData%\Contrast\dotnet\*. As a result, the default file path would be *%ProgramData%\Contrast\dotnet\contrast_security.yaml*.)
 
-## Using Environment Variables
-Every configuration option supported by the *contrast_security.yaml* file can also be specified using environment variables. 
+## Environment Variables
 
-Environment variable names are derived from the yaml path by replacing path segment delimiters (`.`) with double underscores (`__`) and prefixing the result with `CONTRAST__` e.g. `server.name` becomes `CONTRAST__SERVER__NAME` while `api.api_key` becomes `CONTRAST__API__API_KEY`.
+You can use environment variables to specify every configuration option supported by the *contrast_security.yaml* file. Environment variable names are derived from the YAML path by replacing path segment delimiters (`.`) with double underscores (`__`) and prefixing the result with `CONTRAST__`. For example, `server.name` becomes `CONTRAST__SERVER__NAME` while `api.api_key` becomes `CONTRAST__API__API_KEY`.
 
-## Using web.config
-The `application` configuration options can also be specified in an application's `web.config` file. In order for the agent to pick up customized application settings, you must place these settings in the application web.config file's root configuration `appSettings` section.
+## Use web.config
 
-Configuration option names in `web.config` files are derived from the yaml path prefixed with `contrast.` e.g. `application.name` becomes `contrast.application.name`.
+You can also specify the `application` configuration options in an application's *web.config* file. For the agent to pick up customized application settings, you must place these settings in the application *web.config* file's root configuration `appSettings` section.
 
-The following application-specific configuration options can be specified in each application's `web.config` file:
+Configuration option names in *web.config* files are derived from the YAML path prefixed with `contrast.`. For example, `application.name` becomes `contrast.application.name`.
+
+You can specify the following application-specific configuration options in each application's `web.config` file:
 
 * `contrast.application.name`
 * `contrast.application.version`
@@ -47,7 +47,7 @@ The following application-specific configuration options can be specified in eac
 * `contrast.inventory.tags`
 * `contrast.assess.tags`
 
-If `contrast.application.name` is not specified, the .NET agent will use the application's virtual path as an application name. If the application is hosted in the root of a site (i.e., the virtual path is ***/***), then the .NET agent will use the site's name as the application name.
+If `contrast.application.name` is not specified, the .NET agent will use the application's virtual path as an application name. If the application is hosted in the root of a site (i.e., the virtual path is ***/***), the .NET agent will use the site's name as the application name.
 
 ## Configuration Options
 
@@ -77,7 +77,7 @@ Use the following properties for communication with the Contrast UI using certif
     * **store_name**: Specify the name of certificate store to open. The `certificate_location` property must be set to `Store`. Value options include `AuthRoot`, `CertificateAuthority`, `My`, `Root`, `TrustedPeople`, or `TrustedPublisher`.
     * **store_location**: Specify the location of the certificate store. The `certificate_location` property must be set to `Store`. Value options include `CurrentUser` or `LocalMachine`.
     * **find_type**: Specify the type of value the agent uses to find the certificate in the collection of certificates from the certificate store. The `certificate_location` property must be set to `Store`. Value options include `FindByIssuerDistinguishedName`, `FindByIssuerName`, `FindBySerialNumber`, `FindBySubjectDistinguishedName`, `FindBySubjectKeyIdentifier`, `FindBySubjectName`, or `FindByThumbprint`.
-    * **find_value**: Specify the value the agent uses in combination with `find_type` to find a certification in the certificate store. Note that the agent will use the first certificate from the certificate store that matches this search criteria.
+    * **find_value**: Specify the value the agent uses in combination with `find_type` to find a certification in the certificate store. <br> Note: The agent will use the first certificate from the certificate store that matches this search criteria.
     
 #### Proxy
 
@@ -256,10 +256,11 @@ Use the properties in this section to set metadata for the server hosting this a
 
 ## Example Configurations
 
-The following examples can be added to an existing `contrast_security.yaml` file to achieve the example desired behavior.
+You can add the following examples to an existing *contrast_security.yaml* file to achieve the desired behavior.
 
-### Enable Profiler Chaining
-The following configuration enables profiler chaining. This allows the .NET Agent to work alongside other tools that use the CLR Profiling API such as performance APMs.
+### Enable profiler chaining
+
+The following configuration enables profiler chaining. This allows the .NET agent to work alongside other tools that use the CLR Profiling API, such as performance APMs.
 
 ```
 agent:
@@ -267,8 +268,9 @@ agent:
     enable_chaining: true
 ```
 
-### Whitelist an Application Pool for Instrumentation
-The following configuration excludes all application pools except `ExampleAppPool` and `Fabrikam` from instrumentation by the .NET Agent. This can help improve performance on applications you do not wish to analyze.
+### Whitelist an application pool for instrumentation
+
+The following configuration excludes all application pools except `ExampleAppPool` and `Fabrikam` from instrumentation by the .NET agent. This can help improve performance on applications you don't want to analyze.
 
 ```
 agent:
@@ -276,8 +278,9 @@ agent:
     app_pool_whitelist: ExampleAppPool,Fabrikam
 ```
 
-### Disable Auto-update
-The following configuration disables the auto-update feature that automatically downloads and installs new versions of the .NET Agent from Contrast.
+### Disable auto-update
+
+The following configuration disables the auto-update feature that automatically downloads and installs new versions of the .NET agent from Contrast.
 
 ```
 agent:
@@ -285,8 +288,9 @@ agent:
     enable: false
 ```
 
-### Combined Example
-The following configuration enables profiler chaining, specifies an application pool whitelist, disables auto-update, and sets the server name to "MyServer".
+### Combined example
+
+The following configuration enables profiler chaining, specifies an application pool whitelist, disables auto-update and sets the server name to "MyServer".
 
 ```
 agent:

--- a/content/installation/net/configuration/YAML-properties-net.md
+++ b/content/installation/net/configuration/YAML-properties-net.md
@@ -4,7 +4,7 @@ description: "Instructions and template for configuring .NET agent properties vi
 tags: "installation net agent YAML configuration rules properties"
 -->
 
-Contrast support YAML-based configuration for the .NET agent. This allows you to store configuration on disk that you can override with environment variables or command line arguments. Go to the [.NET YAML Template](installation-netconfig.html#net-template) for fully formatted properties that you can copy and use in your own configuration files. 
+Contrast supports YAML-based configuration for the .NET agent. This allows you to store configuration on disk that you can override with environment variables or command line arguments. Go to the [.NET YAML Template](installation-netconfig.html#net-template) for fully formatted properties that you can copy and use in your own configuration files. 
 
 > **Note:** While all Contrast agents share the same property formatting in YAML configuration files, each agent must use its specified file. 
 
@@ -15,9 +15,10 @@ Configuration values use the following order of precedence:
 1. Corporate rule (e.g., expired license overrides `assess.enable`)
 2. Specific environmental variable
 3. Generic environment variable value
-4. User configuration file value
-5. Contrast UI value
-6. Default value 
+4. Application-specific configuration file value (i.e. web.config)
+5. User configuration file value (i.e. contrast_security.yaml)
+6. Contrast UI value
+7. Default value
 
 ## Load Path
 
@@ -25,6 +26,28 @@ The *contrast_security.yaml* file should be placed on the file system using one 
 
 * Specify the path to the YAML file with the environment variable `CONTRAST_CONFIG_PATH`.
 * Place the *contrast_security.yaml* file in the data directory specified during agent install. (The default location is * %ProgramData%\Contrast\dotnet\*. As a result, the default file path would be *%ProgramData%\Contrast\dotnet\contrast_security.yaml*.)
+
+## Using Environment Variables
+Every configuration option supported by the *contrast_security.yaml* file can also be specified using environment variables. 
+
+Environment variable names are derived from the yaml path by replacing path segment delimiters (`.`) with double underscores (`__`) and prefixing the result with `CONTRAST__` e.g. `server.name` becomes `CONTRAST__SERVER__NAME` while `api.api_key` becomes `CONTRAST__API__API_KEY`.
+
+## Using web.config
+The `application` configuration options can also be specified in an application's `web.config` file. In order for the agent to pick up customized application settings, you must place these settings in the application web.config file's root configuration `appSettings` section.
+
+Configuration option names in `web.config` files are derived from the yaml path prefixed with `contrast.` e.g. `application.name` becomes `contrast.application.name`.
+
+The following application-specific configuration options can be specified in each application's `web.config` file:
+
+* `contrast.application.name`
+* `contrast.application.version`
+* `contrast.application.group`
+* `contrast.application.metadata`
+* `contrast.application.tags`
+* `contrast.inventory.tags`
+* `contrast.assess.tags`
+
+If `contrast.application.name` is not specified, the .NET agent will use the application's virtual path as an application name. If the application is hosted in the root of a site (i.e., the virtual path is ***/***), then the .NET agent will use the site's name as the application name.
 
 ## Configuration Options
 
@@ -49,18 +72,20 @@ Use the following properties for communication with the Contrast UI using certif
 
   * **certificate**:
     * **enable**: If set to `false`, the agent will ignore the certificate configuration in this section.
-
+    * **certificate_location**: Determine the location from which the agent loads a client certificate. Value options include `File` or `Store`.
+    * **cer_file**: Set the absolute path to the client certificate's .CER file for communication with Contrast UI. The `certificate_location` property must be set to `File`.
+    * **store_name**: Specify the name of certificate store to open. The `certificate_location` property must be set to `Store`. Value options include `AuthRoot`, `CertificateAuthority`, `My`, `Root`, `TrustedPeople`, or `TrustedPublisher`.
+    * **store_location**: Specify the location of the certificate store. The `certificate_location` property must be set to `Store`. Value options include `CurrentUser` or `LocalMachine`.
+    * **find_type**: Specify the type of value the agent uses to find the certificate in the collection of certificates from the certificate store. The `certificate_location` property must be set to `Store`. Value options include `FindByIssuerDistinguishedName`, `FindByIssuerName`, `FindBySerialNumber`, `FindBySubjectDistinguishedName`, `FindBySubjectKeyIdentifier`, `FindBySubjectName`, or `FindByThumbprint`.
+    * **find_value**: Specify the value the agent uses in combination with `find_type` to find a certification in the certificate store. Note that the agent will use the first certificate from the certificate store that matches this search criteria.
+    
 #### Proxy
 
 Use the following properties for communication with the Contrast UI over a proxy.
-
-  * **certificate**: 
-    * **enable**: If set to `false`, the certificate configuration in this section will be ignored.
   
   * **proxy**:
     * **enable**: Add a property value to determine if the agent should communicate with the Contrast UI over a proxy. If a property value is not present, the presence of a valid proxy host and port determines enabled status. Value options are `true` or `false`
-    * **localhost**: Set the proxy host. It must be set with port and scheme.
-    * **url**: Set this property as an alternate for `scheme://host:port`. It takes precedence over the other settings, if specified; however, an error will be thrown if both the URL and individual properties are set.
+    * **url**: Set the URL of the proxy server.
     * **user**: Set the proxy user.
     * **pass**: Set the proxy password.
     * **auth_type**: Set the proxy authentication type. Value options are `NTLM`, `Digest`, and `Basic`.
@@ -107,14 +132,14 @@ Use the properties in this section to control security logging. These logs allow
 
 Define the following properties to set Syslog values. If the properties are not defined, the agent uses the Syslog values from the Contrast UI.
 
-    * **syslog**:
-      * **enable**: Set to `true` to enable Syslog logging.
-      * **ip**: Set the IP address of the Syslog server to which the agent should send messages.
-      * **port**: Set the port of the Syslog server to which the agent should send messages.
-      * **facility**: Set the facility code of the messages the agent sends to Syslog.
-      * **severity_exploited**: Set the log level of Exploited attacks. Value options are `ALERT`, `CRITICAL`, `ERROR`, `WARNING`, `NOTICE`, `INFO`, and `DEBUG`.
-      * **severity_blocked**: Set the log level of Blocked attacks. Value options are `ALERT`, `CRITICAL`, `ERROR`, `WARNING`, `NOTICE`, `INFO`, and `DEBUG`.
-      * **severity_probed**: Set the log level of Probed attacks. Value options are `ALERT`, `CRITICAL`, `ERROR`, `WARNING`, `NOTICE`, `INFO`, and `DEBUG`.
+  * **security_logger**:
+    * **enable**: Set to `true` to enable Syslog logging.
+    * **ip**: Set the IP address of the Syslog server to which the agent should send messages.
+    * **port**: Set the port of the Syslog server to which the agent should send messages.
+    * **facility**: Set the facility code of the messages the agent sends to Syslog.
+    * **severity_exploited**: Set the log level of Exploited attacks. Value options are `ALERT`, `CRITICAL`, `ERROR`, `WARNING`, `NOTICE`, `INFO`, and `DEBUG`.
+    * **severity_blocked**: Set the log level of Blocked attacks. Value options are `ALERT`, `CRITICAL`, `ERROR`, `WARNING`, `NOTICE`, `INFO`, and `DEBUG`.
+    * **severity_probed**: Set the log level of Probed attacks. Value options are `ALERT`, `CRITICAL`, `ERROR`, `WARNING`, `NOTICE`, `INFO`, and `DEBUG`.
 
 
 #### Agent-specific properties
@@ -159,7 +184,7 @@ Use the properties in this section to control Assess in the .NET agent. The samp
   * **tags**: Apply a list of labels to vulnerabilities and preflight messages. Labels must be formatted as a comma-delimited list. Example: `label1, label2, label3`
   * **stacktraces**: Value options are `ALL`, `SOME`, or `NONE`.
 
-  * **samplings**:
+  * **sampling**:
     * **enable**: Set to `false` to disable sampling.
     * **baseline**: This property indicates the number of requests to analyze in each window before sampling begins. <br> Example: `5`
     * **request_frequency**: This property indicates that every *nth* request after the baseline is analyzed. <br> Example: `10`
@@ -200,6 +225,9 @@ Use the properties in this section to control Protect features and rules.
     * **reflected-xss**:
       * **mode**: Set the mode of the rule. Value options are `monitor`, `block`, `block_at_perimeter`, or `off`. <br> Note: If a setting says, "if blocking is enabled", the setting can be `block` or `block_at_perimeter`.
 
+    * **untrusted-deserialization**:
+      * **mode**: Set the mode of the rule. Value options are `monitor`, `block`, `block_at_perimeter`, or `off`. <br> Note: If a setting says, "if blocking is enabled", the setting can be `block` or `block_at_perimeter`.
+      
     * **xxe**:
       * **mode**: Set the mode of the rule. Value options are `monitor`, `block`, `block_at_perimeter`, or `off`. <br> Note: If a setting says, "if blocking is enabled", the setting can be `block` or `block_at_perimeter`.
 
@@ -226,4 +254,47 @@ Use the properties in this section to set metadata for the server hosting this a
   * **tags**: Apply a list of labels to the server. Labels must be formatted as a comma-delimited list. <br> Example: `label1,label2,label3`
 
 
+## Example Configurations
 
+The following examples can be added to an existing `contrast_security.yaml` file to achieve the example desired behavior.
+
+### Enable Profiler Chaining
+The following configuration enables profiler chaining. This allows the .NET Agent to work alongside other tools that use the CLR Profiling API such as performance APMs.
+
+```
+agent:
+  dotnet:
+    enable_chaining: true
+```
+
+### Whitelist an Application Pool for Instrumentation
+The following configuration excludes all application pools except `ExampleAppPool` from instrumentation by the .NET Agent. This can help improve performance on applications you do not wish to analyze.
+
+```
+agent:
+  dotnet:
+    app_pool_whitelist: ExampleAppPool
+```
+
+### Disable Auto-update
+The following configuration disables the auto-update feature that automatically downloads and installs new versions of the .NET Agent from Contrast.
+
+```
+agent:
+  auto-update:
+    enable: false
+```
+
+### Combined Example
+The following configuration enables profiler chaining, specifies an application pool whitelist, disables auto-update, and sets the server name to "MyServer".
+
+```
+agent:
+  auto-update:
+    enable: false
+  dotnet:
+    enable_chaining: true
+    app_pool_whitelist: ExampleAppPool
+server:
+  name: MyServer
+```

--- a/content/installation/net/configuration/YAML-properties-net.md
+++ b/content/installation/net/configuration/YAML-properties-net.md
@@ -132,7 +132,7 @@ Use the properties in this section to control security logging. These logs allow
 
 Define the following properties to set Syslog values. If the properties are not defined, the agent uses the Syslog values from the Contrast UI.
 
-  * **security_logger**:
+  * **syslog**:
     * **enable**: Set to `true` to enable Syslog logging.
     * **ip**: Set the IP address of the Syslog server to which the agent should send messages.
     * **port**: Set the port of the Syslog server to which the agent should send messages.

--- a/content/installation/net/configuration/YAML-properties-net.md
+++ b/content/installation/net/configuration/YAML-properties-net.md
@@ -268,12 +268,12 @@ agent:
 ```
 
 ### Whitelist an Application Pool for Instrumentation
-The following configuration excludes all application pools except `ExampleAppPool` from instrumentation by the .NET Agent. This can help improve performance on applications you do not wish to analyze.
+The following configuration excludes all application pools except `ExampleAppPool` and `Fabrikam` from instrumentation by the .NET Agent. This can help improve performance on applications you do not wish to analyze.
 
 ```
 agent:
   dotnet:
-    app_pool_whitelist: ExampleAppPool
+    app_pool_whitelist: ExampleAppPool,Fabrikam
 ```
 
 ### Disable Auto-update

--- a/content/installation/net/configuration/YAML-template-net.md
+++ b/content/installation/net/configuration/YAML-template-net.md
@@ -52,30 +52,49 @@ api:
   # Use the following properties for communication
   # with the Contrast UI using certificates.
   # ============================================================================
-  # certificate:
+  certificate:
 
     # If set to `false`, the agent will ignore the
     # certificate configuration in this section.
     # enable: true
+
+    # Determine the location from which the agent loads a client certificate. Value options include `File` or `Store`
+    # certificate_location: 
+
+    # Set the absolute path to the client certificate's .CER file for communication with Contrast UI. 
+    # The `certificate_location` property must be set to `File`.
+    # cer_file: 
+
+    # Specify the name of certificate store to open. The `certificate_location` property must be set to `Store`.
+    # Value options include `AuthRoot`, `CertificateAuthority`, `My`, `Root`, `TrustedPeople`, or `TrustedPublisher`.
+    # store_name: 
+
+    # Specify the location of the certificate store. The `certificate_location` property must be set to `Store`.
+    # Value options include `CurrentUser` or `LocalMachine`.
+    # store_location: 
+
+    # Specify the type of value the agent uses to find the certificate in the collection of certificates from the certificate store.
+    # The `certificate_location` property must be set to `Store`.
+    # Value options include `FindByIssuerDistinguishedName`, `FindByIssuerName`, `FindBySerialNumber`, `FindBySubjectDistinguishedName`, `FindBySubjectKeyIdentifier`, `FindBySubjectName`, or `FindByThumbprint`.
+    # find_type: 
+
+    # Specify the value the agent uses in combination with `find_type` to find a certification in the certificate store.
+    # Note: The agent will use the first certificate from the certificate store that matches this search criteria.
+    # find_value: 
 
   # ============================================================================
   # api.proxy
   # Use the following properties for communication
   # with the Contrast UI over a proxy.
   # ============================================================================
-  # proxy:
+  proxy:
 
     # Add a property value to determine if the agent should communicate with
     # the Contrast UI over a proxy. If a property value is not present, the
     # presence of a valid proxy host and port determines enabled status.
     # enable: NEEDS_TO_BE_SET
 
-    # Set the proxy host. It must be set with port and scheme.
-    # host: localhost
-
-    # Set this property as an alternate for `scheme://host:port`. It takes
-    # precedence over the other settings, if specified; however, an error
-    # will be thrown if both the URL and individual properties are set.
+    # Set the URL of the proxy server.
     # url: NEEDS_TO_BE_SET
 
     # Set the proxy user.
@@ -93,13 +112,12 @@ api:
 # Use the properties in this section to control the way and frequency
 # with which the agent communicates to logs and the Contrast UI.
 # ==============================================================================
-# agent:
+agent:
 
   # ============================================================================
   # agent.auto_update
-  # TODO
   # ============================================================================
-  # auto_update:
+  auto_update:
 
     # Set to `true` for the agent to automatically upgrade to newer versions.
     # enable: true
@@ -115,7 +133,7 @@ api:
   # If the following properties are not defined, the
   # agent uses the logging values from the Contrast UI.
   # ============================================================================
-  # logger:
+  logger:
 
     # Set the the log output level. Valid options are
     # `ERROR`, `WARN`, `INFO`, `DEBUG`, and `TRACE`.
@@ -127,7 +145,7 @@ api:
   # logging values. If not defined, the agent uses the
   # security logging (CEF) values from the Contrast UI.
   # ============================================================================
-  # security_logger:
+  security_logger:
 
     # Set the log level for security logging. Valid options
     # are `ERROR`, `WARN`, `INFO`, `DEBUG`, and `TRACE`.
@@ -142,7 +160,7 @@ api:
     # Define the following properties to set Syslog values. If the properties
     # are not defined, the agent uses the Syslog values from the Contrast UI.
     # ==========================================================================
-    # syslog:
+    syslog:
 
       # Set to `true` to enable Syslog logging.
       # enable: NEEDS_TO_BE_SET
@@ -174,7 +192,7 @@ api:
   # agent.dotnet
   # The following properties apply to any .NET agent-wide configurations.
   # ============================================================================
-  # dotnet:
+  dotnet:
 
     # Set a list of application pool names that the agent does not instrument
     # or analyze. Names must be formatted as a comma-separated list.
@@ -230,7 +248,7 @@ api:
 # inventory
 # Use the properties in this section to override the inventory features.
 # ==============================================================================
-# inventory:
+inventory:
 
   # Set to `false` to disable inventory features in the agent.
   # enable: true
@@ -243,7 +261,7 @@ api:
 # assess
 # Use the properties in this section to control Assess.
 # ==============================================================================
-# assess:
+assess:
 
   # Include this property to determine if the Assess
   # feature should be enabled. If this property is not
@@ -269,7 +287,7 @@ api:
   # assess.sampling
   # Use the following properties to control sampling in the agent.
   # ============================================================================
-  # sampling:
+  sampling:
 
     # Set to `false` to disable sampling.
     # enable: true
@@ -289,7 +307,7 @@ api:
   # assess.rules
   # Use the following properties to control simple rule configurations.
   # ============================================================================
-  # rules:
+  rules:
 
     # Define a list of Assess rules to disable in the agent.
     # The rules must be formatted as a comma-delimited list.
@@ -302,7 +320,7 @@ api:
 # protect
 # Use the properties in this section to override Protect features.
 # ==============================================================================
-# protect:
+protect:
 
   # Use the properties in this section to determine if the
   # Protect feature should be enabled. If this property is not
@@ -323,7 +341,7 @@ api:
   # protect.rules
   # Use the following properties to set simple rule configurations.
   # ============================================================================
-  # rules:
+  rules:
 
     # Define a list of Protect rules to disable in the agent.
     # The rules must be formatted as a comma-delimited list.
@@ -334,7 +352,7 @@ api:
     # Use the following properties to configure
     # if and how the agent blocks bots.
     # ==========================================================================
-    # bot-blocker:
+    bot-blocker:
 
       # Set to `true` for the agent to block known bots.
       # enable: false
@@ -345,7 +363,7 @@ api:
     # Protect rule. The key is the rule ID in the
     # Contrast UI with dashes replaced by underscores.
     # ==========================================================================
-    # sql-injection:
+    sql-injection:
 
       # Set the mode of the rule. Value options are
       # `monitor`, `block`, `block_at_perimeter`, or off.
@@ -359,7 +377,7 @@ api:
     # Use the following properties to configure
     # how the command injection rule works.
     # ==========================================================================
-    # cmd-injection:
+    cmd-injection:
 
       # Set the mode of the rule. Value options are
       # `monitor`, `block`, `block_at_perimeter`, or `off`.
@@ -373,7 +391,7 @@ api:
     # Use the following properties to configure
     # how the path traversal rule works.
     # ==========================================================================
-    # path-traversal:
+    path-traversal:
 
       # Set the mode of the rule. Value options are
       # `monitor`, `block`, `block_at_perimeter`, or `off`.
@@ -387,7 +405,7 @@ api:
     # Use the following properties to configure
     # how the method tampering rule works.
     # ==========================================================================
-    # method-tampering:
+    method-tampering:
 
       # Set the mode of the rule. Value options are
       # `monitor`, `block`, `block_at_perimeter`, or `off`.
@@ -401,7 +419,21 @@ api:
     # Use the following properties to configure how
     # the reflected cross-site scripting rule works.
     # ==========================================================================
-    # reflected-xss:
+    reflected-xss:
+
+      # Set the mode of the rule. Value options are
+      # `monitor`, `block`, `block_at_perimeter`, or `off`.
+      #  
+      # Note - If a setting says, "if blocking is enabled",
+      # the setting can be `block` or `block_at_perimeter`.
+      # mode: monitor
+
+    # ==========================================================================
+    # protect.rules.untrusted-deserialization
+    # Use the following properties to configure how
+    # the untrusted deserialization scripting rule works.
+    # ==========================================================================
+    untrusted-deserialization:
 
       # Set the mode of the rule. Value options are
       # `monitor`, `block`, `block_at_perimeter`, or `off`.
@@ -415,7 +447,7 @@ api:
     # Use the following properties to configure
     # how the XML external entity works.
     # ==========================================================================
-    # xxe:
+    xxe:
 
       # Set the mode of the rule. Value options are
       # `monitor`, `block`, `block_at_perimeter`, or `off`.
@@ -429,7 +461,7 @@ api:
 # Use the properties in this section for
 # the application(s) hosting this agent.
 # ==============================================================================
-# application:
+application:
 
   # Add the name of the application group with which this
   # application should be associated in the Contrast UI.
@@ -457,7 +489,7 @@ api:
 # Use the properties in this section to set
 # metadata for the server hosting this agent.
 # ==============================================================================
-# server:
+server:
 
   # Override the reported server name.
   # name: test-server-1


### PR DESCRIPTION
- Update .NET agent config documentation to be based on common config
- Add details on how to configure via environment variables or via web.config
- Add note about Legacy config options, users should prefer yaml-based config
- Update and add a few missing config options
- Add examples of commonly desired yaml-based configuration 