### PR TITLE
Remove or rewrite info re: request time

### DIFF
--- a/content/troubleshooting/java/application/Java-EffectsOnAppPerformance.md
+++ b/content/troubleshooting/java/application/Java-EffectsOnAppPerformance.md
@@ -13,7 +13,7 @@ When you start your server with Contrast, you'll see a few messages that indicat
 
 ## Request Processing Time
 
-It's probably more important to think about how Contrast affects the round-trip time. In typical applications, Contrast adds around 2x round-trip time to a request that contains a lot of business logic with all the bells and whistles turned on. Round trip times for static resources typically don't get measurably worse. In requests where the total round-trip time is dominated by database or Web Service calls, Contrast's effect will be less noticeable.
+It's probably more important to think about how Contrast affects the round-trip time. Round trip times for static resources typically don't get measurably worse. In requests where the total round-trip time is dominated by database or Web Service calls, Contrast's effect will be less noticeable.
 
 If better performance is really important to your environment, consider the following options:
 


### PR DESCRIPTION
Remove or rewrite this line: :"In typical applications, Contrast adds around 2x round-trip time to a request that contains a lot of business logic with all the bells and whistles turned on."  It's 4 years old and does not seem to be current. Synch with engineering and replace with something more current and accurate, or at least, something more palatable to customers.