### PR TITLE
Basic EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Added basic editor config in an attempt to normalize formatting. This file will be referenced by supporting text editors. These settings mean:

For all files:
- Remove any extra whitespace at the end of lines.
- Ensure there's always a new line at the end of files (aka, every line terminates with a new line character). Since new line characters are on the previous line, this makes diffs easier to read.