### PR TITLE
Contrast 33817 chaining update

### DIFF
--- a/content/installation/netcore/configuration/YAML-properties-netcore.md
+++ b/content/installation/netcore/configuration/YAML-properties-netcore.md
@@ -92,7 +92,6 @@ The following properties apply to any .NET Core agent-wide configurations. <!-- 
     * **enable_jit_inlining**: Indicate that the agent should allow the CLR to inline methods that are not instrumented by Contrast.
     * **skip_profiler_check**: Indicate that the agent should not check for other profilers before starting.
     * **thread_analysis**: Valid values are `full` or `web`. `Full` indicates instrumenting all threading operations to fully follow dataflow. `Web` indicates following dataflow only through built-in sync and async web operations, but not user-managed threads/tasks. Using `web` can improve agent performance.
-    * **enable_chaining:** Enable the profiler chaining feature to allow Contrast to work alongside other tools that use the CLR Profiling API.
 
 
 ### Inventory properties

--- a/content/installation/netcore/configuration/YAML-properties-netcore.md
+++ b/content/installation/netcore/configuration/YAML-properties-netcore.md
@@ -88,8 +88,6 @@ Use the properties in this section to control security logging. These logs allow
 The following properties apply to any .NET Core agent-wide configurations. <!-- More words here... -->
 
   * **dotnet**:
-
-    
     * **enable_instrumentation_optimizations**: Indicate that the agent should allow CLR optimizations of JIT-compiled methods. 
     * **enable_jit_inlining**: Indicate that the agent should allow the CLR to inline methods that are not instrumented by Contrast.
     * **skip_profiler_check**: Indicate that the agent should not check for other profilers before starting.

--- a/content/installation/netcore/configuration/YAML-template-netcore.md
+++ b/content/installation/netcore/configuration/YAML-template-netcore.md
@@ -148,10 +148,6 @@ contrast:
 
     # Valid values are `full` or `web`. `Full` indicates instrumenting all threading operations to fully follow dataflow. `Web` indicates following dataflow only through built-in sync and async web operations, but not user-managed threads/tasks. Using `web` can improve agent performance.
     # thread_analysis: full
-    
-    # Enable an experimental profiler chaining feature to allow Contrast
-    # to work alongside other tools that use the CLR Profiling API.
-    # enable_chaining: false
 
 #===========================================================================
 # Inventory

--- a/content/installation/netcore/install/NetCoreProfilerChaining.md
+++ b/content/installation/netcore/install/NetCoreProfilerChaining.md
@@ -16,14 +16,6 @@ To achieve profiler chaining, you should replace the CORECLR environment variabl
 - `CORECLR_PROFILER_PATH_32` -> `CONTRAST_CCC_CORECLR_PROFILER_PATH_32`
 - `CORECLR_PROFILER_PATH_64` -> `CONTRAST_CCC_CORECLR_PROFILER_PATH_64`
 
-The agent must also have chaining enabled in the [contrast_security.yaml](installation-netcoreconfig.html):
-
-``` yaml
-agent:
-  dotnet:
-    enable_chaining: true
-```
-
 Use the following sets of instructions, which include the changes described above, to set up profiler chaining with [New Relic](#new-relic) or [AppDynamics](#appdynamics). 
 
 ## New Relic
@@ -64,14 +56,6 @@ Complete the following steps to install the .NET Core agent alongside the New Re
     CORECLR_PROFILER={8B2CE134-0948-48CA-A4B2-80DDAD9F5791}
     CONTRAST_CONFIG_PATH=<CONTRAST_CORE_CLR_CONFIG_PATH>\contrast_security.yaml
     ```
-    
-* Use the the [contrast_security.yaml](installation-netcoreconfig.html) to configure the agent to allow chaining:
-
-    ``` yaml
-    agent:
-      dotnet:
-        enable_chaining: true
-    ```
 
 ## AppDynamics
 
@@ -107,14 +91,6 @@ Complete the following steps to install the .NET Core agent alongside the AppDyn
     CORECLR_PROFILER_PATH_32=<CONTRAST_CORE_CLR_HOME>\runtimes\win-x86\native\ContrastProfiler.dll
     CORECLR_PROFILER={8B2CE134-0948-48CA-A4B2-80DDAD9F5791}
     CONTRAST_CONFIG_PATH=<CONTRAST_CORE_CLR_CONFIG_PATH>\contrast_security.yaml
-    ```
-    
-* Use the the [contrast_security.yaml](installation-netcoreconfig.html) to configure the agent to allow chaining:
-
-    ``` yaml
-    agent:
-      dotnet:
-        enable_chaining: true
     ```
 
 ## Next Steps


### PR DESCRIPTION
Removed the yaml flag and guidance for .NET Core chaining. The chaining for net core is just based on the CCC environment variables.