### PR TITLE
Removed Python 3.4 from supported techs

### DIFF
--- a/content/installation/python/PythonSupportedTechnologies.md
+++ b/content/installation/python/PythonSupportedTechnologies.md
@@ -4,7 +4,7 @@ description: "List of supported technologies"
 tags: "installation Python agent frameworks support troubleshooting package"
 -->
 
-The Python agent supports Python versions 2.7+ and 3.4 - 3.6. Framework support is currently for:
+The Python agent supports Python versions 2.7+ and 3.5 to 3.7. Framework support is currently for:
 
 * Django:  1.10+ and 2.0+ <br> (Django 2 is Python 3 only)
 * Flask:   0.10 - 0.12 and 1.0+ 


### PR DESCRIPTION
**NOTE**: Merge after next EOP release

Corresponding JIRA ticket: https://contrast.atlassian.net/browse/CONTRAST-34649