### PR TITLE
CONTRAST-35035 Build Based Views -- Agent Configuration

### DIFF
--- a/content/installation/java/configuration/YAML-properties-java.md
+++ b/content/installation/java/configuration/YAML-properties-java.md
@@ -216,6 +216,8 @@ Use the properties in this section to control the application(s) hosting this ag
   * **version**: Override the reported application version.
   * **tags**: Apply labels to an application. Labels must be formatted as a comma-delimited list. <br> Example: `label1,label2,label3`
   * **metadata**: Define a set of key=value pairs (which conforms to RFC 2253) for specifying user-defined metadata associated with the application. The set must be formatted as a comma-delimited list of `key=value` pairs. <br> Example: "business-unit=accounting, office=Baltimore"
+  * **session_id**: Provide the ID of a session which already exists in the Contrast UI. Vulnerabilities discovered by the agent are associated with this session. If an invalid ID is supplied, the agent will be disabled. This option and `application.session_metadata` are mutually exclusive; if both are set, the agent will be disabled.
+  * **session_metadata**: Provide metadata which is used to create a new session ID in the Contrast UI. Vulnerabilities discovered by the agent are associated with this new session. This value should be formatted as key=value pairs (conforming to RFC 2253). Available key names for this configuration are branchName, buildNumber, commitHash, committer, gitTag, repository, testRun, and version. This option and `application.session_id` are mutually exclusive; if both are set the agent will be disabled.
 
 ### Server properties 
 

--- a/content/installation/java/configuration/YAML-template-java.md
+++ b/content/installation/java/configuration/YAML-template-java.md
@@ -6,8 +6,7 @@ tags: "installation java agent YAML configuration rules properties"
 
 Go to the [YAML Properties](installation-javaconfig.html#java-yaml) article for more information about this template. 
 
-
-```
+```yaml
 # ==============================================================================
 # Use the properties in this YAML file to configure a
 # Contrast agent. Go to https://docs.contrastsecurity.com/ to
@@ -411,6 +410,10 @@ api:
       # chained commands. The agent blocks if blocking is enabled.
       # detect_chained_commands: true
 
+      # Tell the agent to detect when commands come directly
+      # from input. The agent blocks if blocking is enabled.
+      # detect_phased_commands: true
+
     # ==========================================================================
     # protect.rules.path-traversal
     # Use the following properties to configure
@@ -527,6 +530,22 @@ api:
   # set must be formatted as a comma-delimited list of `key=value` pairs.
   # Example - "business-unit=accounting, office=Baltimore"
   # metadata: NEEDS_TO_BE_SET
+
+  # Provide the ID of a session which already exists in the Contrast
+  # UI. Vulnerabilities discovered by the agent are associated with
+  # this session. If an invalid ID is supplied, the agent will be
+  # disabled. This option and `application.session_metadata` are
+  # mutually exclusive; if both are set, the agent will be disabled.
+  # session_id: NEEDS_TO_BE_SET
+
+  # Provide metadata which is used to create a new session ID in the
+  # Contrast UI. Vulnerabilities discovered by the agent are associated
+  # with this new session. This value should be formatted as key=value pairs
+  # (conforming to RFC 2253). Available key names for this configuration
+  # are branchName, buildNumber, commitHash, committer, gitTag, repository,
+  # testRun, and version. This option and `application.session_id` are
+  # mutually exclusive; if both are set the agent will be disabled.
+  # session_metadata: NEEDS_TO_BE_SET
 
 # ==============================================================================
 # server

--- a/content/installation/net/configuration/YAML-properties-net.md
+++ b/content/installation/net/configuration/YAML-properties-net.md
@@ -240,7 +240,8 @@ Use the properties in this section to control the application(s) hosting this ag
   * **version**: Override the reported application version.
   * **tags**: Apply labels to an application. Labels must be formatted as a comma-delimited list. <br> Example: `label1,label2,label3`
   * **metadata**: Define a set of key=value pairs (which conforms to RFC 2253) for specifying user-defined metadata associated with the application. The set must be formatted as a comma-delimited list of `key=value` pairs. <br> Example: "business-unit=accounting, office=Baltimore"
-
+  * **session_id**: Provide the ID of a session which already exists in the Contrast UI. Vulnerabilities discovered by the agent are associated with this session. If an invalid ID is supplied, the agent will be disabled. This option and `application.session_metadata` are mutually exclusive; if both are set, the agent will be disabled.
+  * **session_metadata**: Provide metadata which is used to create a new session ID in the Contrast UI. Vulnerabilities discovered by the agent are associated with this new session. This value should be formatted as key=value pairs (conforming to RFC 2253). Available key names for this configuration are branchName, buildNumber, commitHash, committer, gitTag, repository, testRun, and version. This option and `application.session_id` are mutually exclusive; if both are set the agent will be disabled.
 
 ### Server properties
 

--- a/content/installation/net/configuration/YAML-template-net.md
+++ b/content/installation/net/configuration/YAML-template-net.md
@@ -58,29 +58,41 @@ api:
     # certificate configuration in this section.
     # enable: true
 
-    # Determine the location from which the agent loads a client certificate. Value options include `File` or `Store`
-    # certificate_location:
+    # Determine the location from which the agent loads a client
+    # certificate. Value options include `File` or `Store`.
+    # certificate_location: NEEDS_TO_BE_SET
 
-    # Set the absolute path to the client certificate's .CER file for communication with Contrast UI.
-    # The `certificate_location` property must be set to `File`.
-    # cer_file:
+    # Set the absolute path to the client certificate's
+    # .CER file for communication with Contrast UI. The
+    # `certificate_location` property must be set to `File`.
+    # cer_file: NEEDS_TO_BE_SET
 
-    # Specify the name of certificate store to open. The `certificate_location` property must be set to `Store`.
-    # Value options include `AuthRoot`, `CertificateAuthority`, `My`, `Root`, `TrustedPeople`, or `TrustedPublisher`.
-    # store_name:
+    # Specify the name of certificate store to open. The
+    # `certificate_location` property must be set to `Store`.
+    # Value options include `AuthRoot`, `CertificateAuthority`,
+    # `My`, `Root`, `TrustedPeople`, or `TrustedPublisher`.
+    # store_name: NEEDS_TO_BE_SET
 
-    # Specify the location of the certificate store. The `certificate_location` property must be set to `Store`.
+    # Specify the location of the certificate store. The
+    # `certificate_location` property must be set to `Store`.
     # Value options include `CurrentUser` or `LocalMachine`.
-    # store_location:
+    # store_location: NEEDS_TO_BE_SET
 
-    # Specify the type of value the agent uses to find the certificate in the collection of certificates from the certificate store.
+    # Specify the type of value the agent uses to find the certificate
+    # in the collection of certificates from the certificate store.
     # The `certificate_location` property must be set to `Store`.
-    # Value options include `FindByIssuerDistinguishedName`, `FindByIssuerName`, `FindBySerialNumber`, `FindBySubjectDistinguishedName`, `FindBySubjectKeyIdentifier`, `FindBySubjectName`, or `FindByThumbprint`.
-    # find_type:
+    # Value options include `FindByIssuerDistinguishedName`,
+    # `FindByIssuerName`, `FindBySerialNumber`,
+    # `FindBySubjectDistinguishedName`, `FindBySubjectKeyIdentifier`,
+    # `FindBySubjectName`, or `FindByThumbprint`.
+    # find_type: NEEDS_TO_BE_SET
 
-    # Specify the value the agent uses in combination with `find_type` to find a certification in the certificate store.
-    # Note: The agent will use the first certificate from the certificate store that matches this search criteria.
-    # find_value:
+    # Specify the value the agent uses in combination with
+    # `find_type` to find a certification in the certificate store.
+    #  
+    # Note - The agent will use the first certificate from
+    # the certificate store that matches this search criteria.
+    # find_value: NEEDS_TO_BE_SET
 
   # ============================================================================
   # api.proxy
@@ -94,7 +106,12 @@ api:
     # presence of a valid proxy host and port determines enabled status.
     # enable: NEEDS_TO_BE_SET
 
-    # Set the URL of the proxy server.
+    # Set the proxy host. It must be set with port and scheme.
+    # host: localhost
+
+    # Set this property as an alternate for `scheme://host:port`. It takes
+    # precedence over the other settings, if specified; however, an error
+    # will be thrown if both the URL and individual properties are set.
     # url: NEEDS_TO_BE_SET
 
     # Set the proxy user.
@@ -386,6 +403,10 @@ protect:
       # the setting can be `block` or `block_at_perimeter`.
       # mode: monitor
 
+      # Tell the agent to detect when commands come directly
+      # from input. The agent blocks if blocking is enabled.
+      # detect_phased_commands: true
+
     # ==========================================================================
     # protect.rules.path-traversal
     # Use the following properties to configure
@@ -483,6 +504,22 @@ application:
   # set must be formatted as a comma-delimited list of `key=value` pairs.
   # Example - "business-unit=accounting, office=Baltimore"
   # metadata: NEEDS_TO_BE_SET
+
+  # Provide the ID of a session which already exists in the Contrast
+  # UI. Vulnerabilities discovered by the agent are associated with
+  # this session. If an invalid ID is supplied, the agent will be
+  # disabled. This option and `application.session_metadata` are
+  # mutually exclusive; if both are set, the agent will be disabled.
+  # session_id: NEEDS_TO_BE_SET
+
+  # Provide metadata which is used to create a new session ID in the
+  # Contrast UI. Vulnerabilities discovered by the agent are associated
+  # with this new session. This value should be formatted as key=value pairs
+  # (conforming to RFC 2253). Available key names for this configuration
+  # are branchName, buildNumber, commitHash, committer, gitTag, repository,
+  # testRun, and version. This option and `application.session_id` are
+  # mutually exclusive; if both are set the agent will be disabled.
+  # session_metadata: NEEDS_TO_BE_SET
 
 # ==============================================================================
 # server

--- a/content/installation/node/YAML-properties-node.md
+++ b/content/installation/node/YAML-properties-node.md
@@ -173,6 +173,8 @@ Use the properties in this section to control the application(s) hosting this ag
   * **args**: Pass arguments to the underlying application.
   * **tags**: Apply labels to an application. Labels must be formatted as a comma-delimited list. <br> Example: `label1,label2,label3`
   * **metadata**: Define a set of `key=value` pairs (which conforms to RFC 2253) for specifying user-defined metadata associated with the application. The set must be formatted as a comma-delimited list of `key=value` pairs. <br> Example: "business-unit=accounting, office=Baltimore"
+  * **session_id**: Provide the ID of a session which already exists in the Contrast UI. Vulnerabilities discovered by the agent are associated with this session. If an invalid ID is supplied, the agent will be disabled. This option and `application.session_metadata` are mutually exclusive; if both are set, the agent will be disabled.
+  * **session_metadata**: Provide metadata which is used to create a new session ID in the Contrast UI. Vulnerabilities discovered by the agent are associated with this new session. This value should be formatted as key=value pairs (conforming to RFC 2253). Available key names for this configuration are branchName, buildNumber, commitHash, committer, gitTag, repository, testRun, and version. This option and `application.session_id` are mutually exclusive; if both are set the agent will be disabled.
 
 ### Server properties
 

--- a/content/installation/node/YAML-template-node.md
+++ b/content/installation/node/YAML-template-node.md
@@ -6,7 +6,7 @@ tags: "installation node agent YAML configuration rules properties"
 
 Go to the Node [YAML Properties](installation-nodeconfig.html#node-yaml) article for more information about this template.
 
-```
+```yaml
 # ==============================================================================
 # Use the properties in this YAML file to configure a
 # Contrast agent. Go to https://docs.contrastsecurity.com/ to
@@ -55,10 +55,6 @@ api:
     # If set to `false`, the agent will ignore the
     # certificate configuration in this section.
     # enable: true
-
-    # Allows the agent to communicate data, even if Contrast's cert
-    # can't be verified against supplied list of CAs.
-    # ingnore_cert_errors: NEEDS_TO_BE_SET
 
     # Set the absolute or relative path to a CA for communication
     # with the Contrast UI using a self-signed certificate.
@@ -132,7 +128,7 @@ api:
     # useful information for debugging Contrast. The value set here
     # is the location to which the agent saves log output. If no
     # log file exists at this location, the agent creates a file.
-    #
+    #  
     # Example - */opt/Contrast/contrast.log* creates a log in the
     # */opt/Contrast* directory, and rotates it automatically as needed.
     # path: ./contrast_agent.log
@@ -145,8 +141,8 @@ api:
     # new log file instead of appending and rolling.
     # append: true
 
-    # Set to `true` to log to STDOUT. Set to `false`
-    # for the agent to suppress output to STDOUT.
+    # Set to `true` to log to stdout. Set to `false`
+    # for the agent to suppress output to stdout.
     # stdout: NEEDS_TO_BE_SET
 
   # ============================================================================
@@ -179,8 +175,8 @@ api:
     # the path is determined based on the process' working directory.
     # path: contrast_heap_dumps
 
-    # Set the amount of time to wait, in milliseconds, after
-    # agent startup to begin taking heap dumps.
+    # Set the amount of time to wait, in milliseconds,
+    # after agent startup to begin taking heap dumps.
     # delay_ms: 10_000
 
     # Set the amount of time to wait, in milliseconds, between each heap dump.
@@ -251,15 +247,11 @@ api:
 # application:
 
   # Override the reported application name.
-  #
+  #  
   # Note - On Java systems where multiple, distinct applications may be
   # served by a single process, this configuration causes the agent to report
   # all discovered applications as one application with the given name.
   # name: NEEDS_TO_BE_SET
-
-  # Add the application code this application should use in the Contrast UI.
-  # Example - "the-coolest-node-app"
-  # code: NEEDS_TO_BE_SET
 
   # Override the reported application path.
   # path: NEEDS_TO_BE_SET
@@ -267,6 +259,9 @@ api:
   # Add the name of the application group with which this
   # application should be associated in the Contrast UI.
   # group: NEEDS_TO_BE_SET
+
+  # Add the application code this application should use in the Contrast UI.
+  # code: NEEDS_TO_BE_SET
 
   # Override the reported application version.
   # version: NEEDS_TO_BE_SET
@@ -284,6 +279,22 @@ api:
   # set must be formatted as a comma-delimited list of `key=value` pairs.
   # Example - "business-unit=accounting, office=Baltimore"
   # metadata: NEEDS_TO_BE_SET
+
+  # Provide the ID of a session which already exists in the Contrast
+  # UI. Vulnerabilities discovered by the agent are associated with
+  # this session. If an invalid ID is supplied, the agent will be
+  # disabled. This option and `application.session_metadata` are
+  # mutually exclusive; if both are set, the agent will be disabled.
+  # session_id: NEEDS_TO_BE_SET
+
+  # Provide metadata which is used to create a new session ID in the
+  # Contrast UI. Vulnerabilities discovered by the agent are associated
+  # with this new session. This value should be formatted as key=value pairs
+  # (conforming to RFC 2253). Available key names for this configuration
+  # are branchName, buildNumber, commitHash, committer, gitTag, repository,
+  # testRun, and version. This option and `application.session_id` are
+  # mutually exclusive; if both are set the agent will be disabled.
+  # session_metadata: NEEDS_TO_BE_SET
 
 # ==============================================================================
 # server
@@ -314,5 +325,5 @@ api:
   # must be formatted as a comma-delimited list.
   # Example - label1,label2,label3
   # tags: NEEDS_TO_BE_SET
-  
+
 ```

--- a/content/installation/python/Python-template.md
+++ b/content/installation/python/Python-template.md
@@ -6,7 +6,7 @@ tags: "installation python django flask pyramid agent service configuration"
 
 Go to the Python [Configuration Properties](installation-pythonconfig.html#python-config) article for more information about this template.
 
-```
+```yaml
 # ==============================================================================
 # Use the properties in this YAML file to configure a
 # Contrast agent. Go to https://docs.contrastsecurity.com/ to

--- a/content/installation/python/PythonConfig.md
+++ b/content/installation/python/PythonConfig.md
@@ -149,7 +149,9 @@ Use the properties in this section for the application(s) hosting each agent.
   * **code**: Add the application code this application should use in the Contrast UI.
   * **version**: Override the reported application version.
   * **tags**: Apply labels to an application. Labels must be formatted as a comma-delimited list. <br> Example: `label1,label2,label3`
-   * **metadata**: Define a set of key=value pairs (which conforms to RFC 2253) for specifying user-defined metadata associated with the application. The set must be formatted as a comma-delimited list of `key=value` pairs. <br> Example: "business-unit=accounting, office=Baltimore"
+  * **metadata**: Define a set of key=value pairs (which conforms to RFC 2253) for specifying user-defined metadata associated with the application. The set must be formatted as a comma-delimited list of `key=value` pairs. <br> Example: "business-unit=accounting, office=Baltimore"
+  * **session_id**: Provide the ID of a session which already exists in the Contrast UI. Vulnerabilities discovered by the agent are associated with this session. If an invalid ID is supplied, the agent will be disabled. This option and `application.session_metadata` are mutually exclusive; if both are set, the agent will be disabled.
+  * **session_metadata**: Provide metadata which is used to create a new session ID in the Contrast UI. Vulnerabilities discovered by the agent are associated with this new session. This value should be formatted as key=value pairs (conforming to RFC 2253). Available key names for this configuration are branchName, buildNumber, commitHash, committer, gitTag, repository, testRun, and version. This option and `application.session_id` are mutually exclusive; if both are set the agent will be disabled.
 
 ### Server properties
 

--- a/content/installation/ruby/Ruby-template.md
+++ b/content/installation/ruby/Ruby-template.md
@@ -6,7 +6,7 @@ tags: "installation ruby on rails agent service configuration"
 
 Go to the Ruby [Configuration Properties](installation-rubyconfig.html#ruby-config) article for more information about this template.
 
-```
+```yaml
 # ==============================================================================
 # Use the properties in this YAML file to configure a
 # Contrast agent. Go to https://docs.contrastsecurity.com/ to
@@ -219,7 +219,7 @@ agent:
 
       # Override the name of the process used in logs.
       # progname: Contrast Service
-      
+
   # ============================================================================
   # agent.heap_dump
   # The following properties are used to trigger heap dumps from within
@@ -231,18 +231,18 @@ agent:
     # take heap dumps of the instrumented application.
     # enable: false
 
-    # The location to which to save the heap dump files. If relative,
+    # Set the location to which to save the heap dump files. If relative,
     # the path is determined based on the process' working directory.
     # path: contrast_heap_dumps
 
-    # How long to wait, in milliseconds, after
-    # agent startup to begin taking heap dumps.
+    # Set the amount of time to wait, in milliseconds,
+    # after agent startup to begin taking heap dumps.
     # delay_ms: 10_000
 
-    # How long to wait, in milliseconds, between each heap dump.
+    # Set the amount of time to wait, in milliseconds, between each heap dump.
     # window_ms: 10_000
 
-    # The number of heap dumps to take before disabling this feature.
+    # Set the number of heap dumps to take before disabling this feature.
     # count: 5
 
     # Set to `true` for the agent to trigger garbage collection before
@@ -482,6 +482,22 @@ agent:
   # set must be formatted as a comma-delimited list of `key=value` pairs.
   # Example - "business-unit=accounting, office=Baltimore"
   # metadata: NEEDS_TO_BE_SET
+
+  # Provide the ID of a session which already exists in the Contrast
+  # UI. Vulnerabilities discovered by the agent are associated with
+  # this session. If an invalid ID is supplied, the agent will be
+  # disabled. This option and `application.session_metadata` are
+  # mutually exclusive; if both are set, the agent will be disabled.
+  # session_id: NEEDS_TO_BE_SET
+
+  # Provide metadata which is used to create a new session ID in the
+  # Contrast UI. Vulnerabilities discovered by the agent are associated
+  # with this new session. This value should be formatted as key=value pairs
+  # (conforming to RFC 2253). Available key names for this configuration
+  # are branchName, buildNumber, commitHash, committer, gitTag, repository,
+  # testRun, and version. This option and `application.session_id` are
+  # mutually exclusive; if both are set the agent will be disabled.
+  # session_metadata: NEEDS_TO_BE_SET
 
 # ==============================================================================
 # server

--- a/content/installation/ruby/RubyConfig.md
+++ b/content/installation/ruby/RubyConfig.md
@@ -196,6 +196,8 @@ For **application** tags, update the configuration of the agent. If there isn’
   * **version**: Override the reported application version.
   * **tags**: Apply labels to an application. Labels must be formatted as a comma-delimited list. <br> Example: `label1,label2,label3`
   * **metadata**: Define a set of key=value pairs (which conforms to RFC 2253) for specifying user-defined metadata associated with the application. The set must be formatted as a comma-delimited list of `key=value` pairs. <br> Example: "business-unit=accounting, office=Baltimore"
+  * **session_id**: Provide the ID of a session which already exists in the Contrast UI. Vulnerabilities discovered by the agent are associated with this session. If an invalid ID is supplied, the agent will be disabled. This option and `application.session_metadata` are mutually exclusive; if both are set, the agent will be disabled.
+  * **session_metadata**: Provide metadata which is used to create a new session ID in the Contrast UI. Vulnerabilities discovered by the agent are associated with this new session. This value should be formatted as key=value pairs (conforming to RFC 2253). Available key names for this configuration are branchName, buildNumber, commitHash, committer, gitTag, repository, testRun, and version. This option and `application.session_id` are mutually exclusive; if both are set the agent will be disabled.
 
 ### Server properties
 


### PR DESCRIPTION
:pencil: move yaml in line with agreed upon common configuration

I mainly care about the `session_id` and `session_metadata` params, but the others are out of line w/ common config, so they just got updated in the paste. I can revert if anyone has objections.