### PR TITLE
✨ CONTRAST-36484 contrast-java-agent-exec-helper docs

### DIFF
--- a/content/installation/java/host/RedHatHosts.md
+++ b/content/installation/java/host/RedHatHosts.md
@@ -1,0 +1,53 @@
+<!--
+title: "Install the Java Agent on a Red Hat Host"
+description: "Installing the Java Agent Across All Java Processes on a Red Hat Host"
+tags: "installation Java agent linux package red hat centos rhel exec-helper yum dnf host"
+-->
+
+Red Hat Enterprise Linux (RHEL) and CentOS users may install the Contrast Java agent at the host level using the `contrast-java-agent-exec-helper`. The `contrast-java-agent-exec-helper` configures the RHEL or CentOS host to include the Contrast Java agent on all Java processes on the host.
+
+Instead of a typical Contrast installation that requires users to configure their Java services to include the Contrast Java agent, the `contrast-java-agent-exec-helper` package intercepts all new `java` processes, and automatically configures the process to use Contrast.
+
+This option is ideal for some scenarios in which Contrast must support legacy infrastructure but your Java application server configuration isn't well understood. However, in most scenarios, administrators want more granular control over their Contrast configurations.
+
+### Installing the Contrast Java agent with the contrast-java-agent-exec-helper
+
+* Use the following commands to configure your system to retrieve packages from the Contrast RPM repository:
+
+```console
+OSREL=$(rpmquery -E "%{rhel}")
+sudo -E tee /etc/yum.repos.d/contrast.repo << EOF
+[contrast]
+name=contrast repo
+baseurl=https://pkg.contrastsecurity.com/rpm-public/centos-$OSREL/
+gpgcheck=0
+enabled=1
+EOF
+```
+
+* Once you've finished configuration, install the `contrast-java-agent` and `contrast-java-agent-exec-helper` packages:
+
+```console
+sudo yum install contrast-java-agent contrast-java-agent-exec-helper
+```
+
+Although the *jar* file you can [download from the Contrast UI](installation-javastandard.html#contrast-ui) is preconfigured with connection parameters, you must provide Contrast connection parameters using the agent [configuration properties](installation-javaconfig.html) when using the *contrast-agent.jar* from the Contrast RPM repository.
+
+* Verify that the Exec Helper is working by executing `java` and confirming that Contrast starts by observing console messages.
+
+```
+$ bash -c "java -Dcontrast.stdout=true -version 2>1 | grep Contrast | head -n 1"
+[Contrast] Wed Aug 15 17:37:23 UTC 2018 No TeamServer configuration detected. Agent will only be reporting to local listeners (e.g., Eclipse Plugin).
+```
+
+* The Contrast Java agent Exec Helper affects all new shells, as indicated by the `bash -c` in the verification command. Consequently, it will not be present in your current shell. Reload your shell to enable the Contrast Java agent Exec Helper. Restart any `java` services to enable Contrast for those services.
+
+> **Note:** The Exec Helper package expects to find the Contrast Java agent at */opt/contrast/contrast.jar*, where the `contrast-java-agent` packages installs it. If the Contrast *jar* file has a different path, use environment variable `CONTRAST_JAVA_AGENT_PATH` to configure the `contrast-java-agent-exec-helper`.
+
+#### Logging
+
+The Exec Helper logs messages to the host's Syslog service using the identifier "Contrast". The Exec Helper uses the "user.warn" and "user.debug" Syslog facility and level, respectively. Use `journalctl` to view the messages (i.e., `journalctl -t Contrast`). Traditional init.v systems, including EL6, store Syslog messages in the file */var/log/messages* by default instead of the systemd Journal.
+
+## Learn More
+
+If you're experiencing issues with the Exec Helper package after installation, go to the [troubleshooting article](troubleshooting-javainstall.html#java-exec) for more help with startup, logging and libraries.

--- a/content/installation/java/host/RedHatHosts.md
+++ b/content/installation/java/host/RedHatHosts.md
@@ -1,16 +1,16 @@
 <!--
 title: "Install the Java Agent on a Red Hat Host"
-description: "Installing the Java Agent Across All Java Processes on a Red Hat Host"
+description: "How to install the Java agent across all Java processes on a Red Hat host"
 tags: "installation Java agent linux package red hat centos rhel exec-helper yum dnf host"
 -->
 
-Red Hat Enterprise Linux (RHEL) and CentOS users may install the Contrast Java agent at the host level using the `contrast-java-agent-exec-helper`. The `contrast-java-agent-exec-helper` configures the RHEL or CentOS host to include the Contrast Java agent on all Java processes on the host.
+## About Host Installation for RHEL
 
-Instead of a typical Contrast installation that requires users to configure their Java services to include the Contrast Java agent, the `contrast-java-agent-exec-helper` package intercepts all new `java` processes, and automatically configures the process to use Contrast.
+Red Hat Enterprise Linux (RHEL) and CentOS users may install the Contrast Java agent at the host level using the `contrast-java-agent-exec-helper` package. The Exec Helper configures the RHEL or CentOS host to include the Contrast Java agent on all Java processes on the host.
 
-This option is ideal for some scenarios in which Contrast must support legacy infrastructure but your Java application server configuration isn't well understood. However, in most scenarios, administrators want more granular control over their Contrast configurations.
+Instead of a typical Contrast installation that requires users to configure their Java services to include the Contrast Java agent, the `contrast-java-agent-exec-helper` package intercepts all new `java` processes, and automatically configures the process to use Contrast. This option is ideal for some scenarios in which Contrast must support legacy infrastructure but your Java application server configuration isn't well understood. However, in most scenarios, administrators want more granular control over their Contrast configurations.
 
-### Installing the Contrast Java agent with the contrast-java-agent-exec-helper
+## Install the Agent with the Exec Helper Package
 
 * Use the following commands to configure your system to retrieve packages from the Contrast RPM repository:
 
@@ -44,7 +44,7 @@ $ bash -c "java -Dcontrast.stdout=true -version 2>1 | grep Contrast | head -n 1"
 
 > **Note:** The Exec Helper package expects to find the Contrast Java agent at */opt/contrast/contrast.jar*, where the `contrast-java-agent` packages installs it. If the Contrast *jar* file has a different path, use environment variable `CONTRAST_JAVA_AGENT_PATH` to configure the `contrast-java-agent-exec-helper`.
 
-#### Logging
+### Logging
 
 The Exec Helper logs messages to the host's Syslog service using the identifier "Contrast". The Exec Helper uses the "user.warn" and "user.debug" Syslog facility and level, respectively. Use `journalctl` to view the messages (i.e., `journalctl -t Contrast`). Traditional init.v systems, including EL6, store Syslog messages in the file */var/log/messages* by default instead of the systemd Journal.
 

--- a/content/installation/java/host/UbuntuHosts.md
+++ b/content/installation/java/host/UbuntuHosts.md
@@ -1,0 +1,51 @@
+<!--
+title: "Install the Java Agent on an Ubuntu Host"
+description: "Installing the Java Agent Across All Java Processes on an Ubuntu Host"
+tags: "installation Java agent linux package ubuntu bionic trusty xenial debian apt exec-helper host"
+-->
+
+Ubuntu users may install the Contrast Java agent at the host level using the `contrast-java-agent-exec-helper`. The `contrast-java-agent-exec-helper` configures the Ubuntu host to attach the Contrast Java agent on all Java processes on the host.
+
+Instead of a typical Contrast installation that requires users to configure their Java service scripts to include the Contrast Java agent, the `contrast-java-agent-exec-helper` package intercepts all new `java` processes, and automatically configures those processes to use Contrast.
+
+This option is ideal for some scenarios in which Contrast must support legacy infrastructure but your Java application server configuration isn't well understood. However, in most scenarios, administrators want more granular control over their Contrast configurations.
+
+
+### Installing the Contrast Java agent with the contrast-java-agent-exec-helper
+
+The contrast-java-agent-exec-helper supports Ubuntu LTS distributions Trusty, Xenial, and Bionic.
+
+* To install the contrast-java-agent-exec-helper from Contrast's Debian repository, configure your system to use the repository tailored for your Ubuntu LTS distribution.
+
+```console
+curl https://contrastsecurity.jfrog.io/contrastsecurity/api/gpg/key/public | sudo apt-key add -
+echo "deb https://contrastsecurity.jfrog.io/contrastsecurity/debian-public/ $(bash -c '. /etc/lsb-release && echo $DISTRIB_CODENAME') contrast" | sudo tee /etc/apt/sources.list.d/contrast-$(bash -c '. /etc/lsb-release && echo $DISTRIB_CODENAME').list
+echo "deb https://pkg.contrastsecurity.com/debian-public/ all contrast" | sudo tee /etc/apt/sources.list.d/contrast-all.list
+```
+
+* Once you've finished configuration, install the `contrast-java-agent` and `contrast-java-agent-exec-helper` packages.
+
+```
+sudo apt-get update && sudo apt-get install contrast-java-agent contrast-java-agent-exec-helper
+```
+
+Although the *jar* file you can [download from the Contrast UI](installation-javastandard.html#contrast-ui) is preconfigured with connection parameters, you must provide Contrast connection parameters using the agent [configuration properties](installation-javaconfig.html) when using the *contrast-agent.jar* from the Contrast RPM repository.
+
+* Verify that the Exec Helper is working by executing `java` and confirming that Contrast starts by observing console messages.
+
+```
+$ bash -c "java -Dcontrast.stdout=true -version 2>1 | grep Contrast | head -n 1"
+[Contrast] Wed Aug 15 17:37:23 UTC 2018 No TeamServer configuration detected. Agent will only be reporting to local listeners (e.g., Eclipse Plugin).
+```
+
+* The Exec Helper affects all new shells, as indicated by the `bash -c` in the verification command. Consequently, it will not be present in your current shell. Reload your shell to enable the Exec Helper. Restart any `java` services to enable Contrast for those services.
+
+> **Note:** The Exec Helper package expects to find the Contrast Java agent at */opt/contrast/contrast.jar*, where the `contrast-java-agent` package installs it. If the Contrast *jar* file has a different path, use environment variable `CONTRAST_JAVA_AGENT_PATH` to configure `contrast-java-agent-exec-helper`.
+
+#### Logging
+
+The Exec Helper logs messages to the host's Syslog service using the identifier "Contrast". The Exec Helper uses the "user.warn" and "user.debug" Syslog facility and level, respectively. Use `journalctl` to view the messages (i.e., `journalctl -t Contrast`). Traditional init.v systems, including Ubuntu 14.04, store Syslog messages in the file */var/log/messages* by default instead of the systemd Journal.
+
+## Learn More
+
+If you're experiencing issues with the Exec Helper package after installation, go to the [troubleshooting article](troubleshooting-javainstall.html#java-exec) for more help with startup, logging and libraries.

--- a/content/installation/java/host/UbuntuHosts.md
+++ b/content/installation/java/host/UbuntuHosts.md
@@ -4,18 +4,17 @@ description: "Installing the Java Agent Across All Java Processes on an Ubuntu H
 tags: "installation Java agent linux package ubuntu bionic trusty xenial debian apt exec-helper host"
 -->
 
+## About Host Installation for Ubuntu
+
 Ubuntu users may install the Contrast Java agent at the host level using the `contrast-java-agent-exec-helper`. The `contrast-java-agent-exec-helper` configures the Ubuntu host to attach the Contrast Java agent on all Java processes on the host.
 
-Instead of a typical Contrast installation that requires users to configure their Java service scripts to include the Contrast Java agent, the `contrast-java-agent-exec-helper` package intercepts all new `java` processes, and automatically configures those processes to use Contrast.
+Instead of a typical Contrast installation that requires users to configure their Java service scripts to include the Contrast Java agent, the `contrast-java-agent-exec-helper` package intercepts all new `java` processes, and automatically configures those processes to use Contrast. This option is ideal for some scenarios in which Contrast must support legacy infrastructure but your Java application server configuration isn't well understood. However, in most scenarios, administrators want more granular control over their Contrast configurations.
 
-This option is ideal for some scenarios in which Contrast must support legacy infrastructure but your Java application server configuration isn't well understood. However, in most scenarios, administrators want more granular control over their Contrast configurations.
+## Install the Agent with the Exec Helper Package
 
+The Contrast Java agent Exec Helper supports Ubuntu LTS distributions Trusty, Xenial and Bionic.
 
-### Installing the Contrast Java agent with the contrast-java-agent-exec-helper
-
-The contrast-java-agent-exec-helper supports Ubuntu LTS distributions Trusty, Xenial, and Bionic.
-
-* To install the contrast-java-agent-exec-helper from Contrast's Debian repository, configure your system to use the repository tailored for your Ubuntu LTS distribution.
+* To install the `contrast-java-agent-exec-helper` package from Contrast's Debian repository, configure your system to use the repository tailored for your Ubuntu LTS distribution:
 
 ```console
 curl https://contrastsecurity.jfrog.io/contrastsecurity/api/gpg/key/public | sudo apt-key add -
@@ -23,7 +22,7 @@ echo "deb https://contrastsecurity.jfrog.io/contrastsecurity/debian-public/ $(ba
 echo "deb https://pkg.contrastsecurity.com/debian-public/ all contrast" | sudo tee /etc/apt/sources.list.d/contrast-all.list
 ```
 
-* Once you've finished configuration, install the `contrast-java-agent` and `contrast-java-agent-exec-helper` packages.
+* Once you've finished configuration, install the `contrast-java-agent` and `contrast-java-agent-exec-helper` packages:
 
 ```
 sudo apt-get update && sudo apt-get install contrast-java-agent contrast-java-agent-exec-helper
@@ -31,7 +30,7 @@ sudo apt-get update && sudo apt-get install contrast-java-agent contrast-java-ag
 
 Although the *jar* file you can [download from the Contrast UI](installation-javastandard.html#contrast-ui) is preconfigured with connection parameters, you must provide Contrast connection parameters using the agent [configuration properties](installation-javaconfig.html) when using the *contrast-agent.jar* from the Contrast RPM repository.
 
-* Verify that the Exec Helper is working by executing `java` and confirming that Contrast starts by observing console messages.
+* Verify that the Exec Helper is working by executing `java` and confirming that Contrast starts by observing console messages:
 
 ```
 $ bash -c "java -Dcontrast.stdout=true -version 2>1 | grep Contrast | head -n 1"
@@ -42,7 +41,7 @@ $ bash -c "java -Dcontrast.stdout=true -version 2>1 | grep Contrast | head -n 1"
 
 > **Note:** The Exec Helper package expects to find the Contrast Java agent at */opt/contrast/contrast.jar*, where the `contrast-java-agent` package installs it. If the Contrast *jar* file has a different path, use environment variable `CONTRAST_JAVA_AGENT_PATH` to configure `contrast-java-agent-exec-helper`.
 
-#### Logging
+### Logging
 
 The Exec Helper logs messages to the host's Syslog service using the identifier "Contrast". The Exec Helper uses the "user.warn" and "user.debug" Syslog facility and level, respectively. Use `journalctl` to view the messages (i.e., `journalctl -t Contrast`). Traditional init.v systems, including Ubuntu 14.04, store Syslog messages in the file */var/log/messages* by default instead of the systemd Journal.
 

--- a/content/troubleshooting/java/installation/exec-helper-troubleshooting.md
+++ b/content/troubleshooting/java/installation/exec-helper-troubleshooting.md
@@ -1,0 +1,27 @@
+
+<!--
+title: "Troubleshooting Java Agent Installation with the Exec Helper package"
+description: "Troubleshooting with the Exec Helper package"
+tags: "troubleshooting installation Java agent linux exec package"
+-->
+
+
+## Issue: The Exec Helper is installed, but Contrast isn't starting
+
+You must reload the shell for the installer to take effect.
+
+When you restart your web application server with a Daemon Manager like systemd or an init.v script, this is done for you; but, if you're trying to start up a web application in your user's shell (e.g., `java -jar webgoat.jar`), you must first reload your shell.
+
+## Issue: I don't know where the Exec Helper logs messages
+
+The Exec Helper logs messages to the host's Syslog service using the identifier "Contrast". The Exec Helper uses the "user.warn" and "user.debug" Syslog facility and level, respectively.
+
+Newer systems which use systemd, including EL7 and Ubuntu 16.04, store Syslog messages in the systemd journal. Use `journalctl` to view the messages (i.e., `journalctl -t Contrast`). Traditional init.v systems, including EL6 and Ubuntu 14.04, store Syslog messages in the file */var/log/messages* by default.
+
+If there aren't any logs in either of these storage locations, verify Syslog configuration `/etc/syslog.conf`; the host may be configured to drop the message types or log level used by the Exec Helper.
+
+## Issue: I removed the libcontrast_exec_helper.so libraries, and now my system errors on every command I run
+
+The host emits these errors because the *&ast;nix* system has been globally configured to load the *libcontrast_exec_helper.so* library for every binary on the system to determine if it should inject the Java agent into it. Even if you manually removed the library, the global configuration of dynamic loader is still referencing it and is failing/warning when it can't find the file.
+
+Open up the */etc/ld.so.preload* file as root and remove the entry for the Contrast libraries.


### PR DESCRIPTION
Adds page "Host Installation" with two articles

1. Red Hat Hosts
1. Ubuntu Hosts

Adds a troubleshooting page for the contrast-java-agent-exec-helper.

I've deployed the contrast-java-agent-exec-helper to production, so these changes are all that's left to release this feature.