### PR TITLE
CONTRAST-36805 - alpine instructions

### DIFF
--- a/content/installation/ruby/RubyMuslC.md
+++ b/content/installation/ruby/RubyMuslC.md
@@ -13,8 +13,10 @@ Contrast requires compilation in the local environment to install *C* libraries.
 The least invasive option is to reinstall a single gem. After installing the Contrast gem, uninstall its dependency and re-install using the `ruby` platform flag.
 
 ```
+CS__PROTOBUF="$(gem list | grep google-protobuf | grep -o '[0-9]*\.[0-9]*\.[0-9]*')"
 gem uninstall -I google-protobuf
-gem install google-protobuf --version=3.7.1 --platform=ruby
+gem install google-protobuf --version=$CS__PROTOBUF --platform=ruby
+unset CS__PROTOBUF
 ```
 
 ### Reinstall full platform


### PR DESCRIPTION
:pencil: update instructions to be dynamic

I'd like to get ahead of our next dependency update and make the instructions for attempting MuslC / Alpine compatibility more flexible. This script allows for that by removing the hardcoded version number. We're testing these steps ourselves in one of our testing environments to make sure they work. 