### PR TITLE
Add official yarn support

### DIFF
--- a/content/installation/node/NodeInstall.md
+++ b/content/installation/node/NodeInstall.md
@@ -4,30 +4,6 @@ description: "Installing the Node.js Agent"
 tags: "NodeJS agent installation"
 -->
 
-## Prerequisites
-
-To install the Node agent, you must have installed:
-
-* A C++ compiler toolchain (e.g., Clang, GCC or MSVC) and a POSIX-compatible `make`
-
-* Python (which is needed for [Node-gyp](https://github.com/nodejs/node-gyp), Node's build tool, to function)
-
-> **Notes:**
- * If you can build other modules with C++ bindings like [node-sass](https://www.npmjs.com/package/node-sass) and [sqlite3](https://github.com/mapbox/node-sqlite3), you probably meet all of the requirements for Contrast.
- * The official [Node Docker images](https://hub.docker.com/_/node/) come with all of the prerequisites installed.
-
-### Windows
-
-To install the necessary compiler toolchain on Windows, run `npm install -g --production windows-build-tools`. If you're using a Node version older than 8.0, you must use `windows-build-tools` version 3.0 (not 4.0, the newest version).
-
-### macOS
-
-macOS ships with the `clang` compiler suite. Use `clang --version` to ensure that you have the compiler installed. If Clang is **not** already installed, run `$ xcode-select --install` to install it.
-
-### Linux
-
-Linux distributions often ship with a C++ compiler toolchain. You can verify that the compiler is installed with `c++ --version`. If you don't have a C++ compiler installed, install the `g++` package available from most Linux package managers.
-
 
 ## Installation
 
@@ -38,10 +14,10 @@ npm install node-contrast-#.#.#.tgz --no-save
 ```
 This will add the agent to your *node_modules* folder without creating an entry in the dependencies list of your *package.json*.
 
-> **Note:** If you use yarn, you can't run `yarn add node-contrast-#.#.#.tgz`. Yarn has known issues with packages that contain bundled dependencies like our agent package. Run the following **after** you install yarn:
- ``` sh
- mkdir -p node_modules/node_contrast && tar zxvf node_contrast-#.#.#.tgz --strip 1 -C node_modules/node_contrast
- ```
+If you use yarn:
+``` sh
+yarn add file:node-contrast-#.#.#.tgz
+```
 
 ## Setup
 

--- a/content/installation/node/NodeSupportedTechnologies.md
+++ b/content/installation/node/NodeSupportedTechnologies.md
@@ -34,12 +34,12 @@ Contrast doesn't guarantee support for old or deprecated versions of third-party
 
 ## OS Support
 
-The agent runs in the Node.js application layer with some C++ dependencies. As a result, it works on **the same operating systems as Node.js**, including Linux, Windows, macOS and other Unix-like systems, assuming there is a C++ compiler toolchain installed.
+The agent runs in the Node.js application layer. As a result, it works on **the same operating systems as Node.js**, including Linux, Windows, macOS and other Unix-like systems.
 
 ## Testing Environments
 
 When changes are made, Contrast runs a battery of automated tests to ensure that it detects findings in supported technologies across all supported versions of Node. This includes tests that exercise the agent against Contrast's
-[Node Test Bench](https://github.com/Contrast-Security-OSS/NodeTestBench), [Hapi 16 Test Bench](https://github.com/Contrast-Security-OSS/Hapi16TestBench), [Hapi 17 Test Bench](https://github.com/Contrast-Security-OSS/HapiTestBench/tree/hapi17) and [Hapi 18 Test Bench](https://github.com/Contrast-Security-OSS/HapiTestBench/tree/hapi18) applications. Each of these applications is updated as Contrast adds more third-party library support to the agent.
+[Express Test Bench](https://github.com/Contrast-Security-OSS/NodeTestBench), [Koa Test Bench](https://github.com/contrast-security-oss/KoaTestBench), [Hapi 16 Test Bench](https://github.com/Contrast-Security-OSS/Hapi16TestBench), [Hapi 17 Test Bench](https://github.com/Contrast-Security-OSS/HapiTestBench/tree/hapi17) and [Hapi 18 Test Bench](https://github.com/Contrast-Security-OSS/HapiTestBench/tree/hapi18) applications. Each of these applications is updated as Contrast adds more third-party library support to the agent.
 
 If you want to add test cases, let Contrast know by clicking on the link of your chosen application and submitting a pull request.
 

--- a/content/troubleshooting/node/Compilers.md
+++ b/content/troubleshooting/node/Compilers.md
@@ -1,0 +1,29 @@
+<!--
+title: "Node.js Compiler Installation"
+description: "Installing a compiler for Node.js agent < 2.6.0"
+tags: "Node.js compiler installation"
+-->
+## Compiler Installation
+
+From 2.0.0 to 2.5.1 of the Node agent, you must have installed:
+
+* A C++ compiler toolchain (e.g., Clang, GCC or MSVC) and a POSIX-compatible `make`
+
+* Python (which is needed for [Node-gyp](https://github.com/nodejs/node-gyp), Node's build tool, to function)
+
+> **Notes:**
+ * If you can build other modules with C++ bindings like [node-sass](https://www.npmjs.com/package/node-sass) and [sqlite3](https://github.com/mapbox/node-sqlite3), you probably meet all of the requirements for Contrast.
+ * The official [Node Docker images](https://hub.docker.com/_/node/) come with all of the prerequisites installed.
+
+### Windows
+
+To install the necessary compiler toolchain on Windows, run `npm install -g --production windows-build-tools`. If you're using a Node version older than 8.0, you must use `windows-build-tools` version 3.0 (not 4.0, the newest version).
+
+### macOS
+
+macOS ships with the `clang` compiler suite. Use `clang --version` to ensure that you have the compiler installed. If Clang is **not** already installed, run `$ xcode-select --install` to install it.
+
+### Linux
+
+Linux distributions often ship with a C++ compiler toolchain. You can verify that the compiler is installed with `c++ --version`. If you don't have a C++ compiler installed, install the `g++` package available from most Linux package managers.
+

--- a/content/troubleshooting/node/TroubleshootNodeAgent.md
+++ b/content/troubleshooting/node/TroubleshootNodeAgent.md
@@ -4,6 +4,20 @@ description: "General troubleshooting guide for the Node agent"
 tags: "node troubleshooting agent general debug"
 -->
 
+## Scenario: Unable to install Node agent.
+
+If you see the following errors during npm install of Node agent
+```
+npm ERR! @contrast/distringuish@1.2.0 build: `node-gyp rebuild`
+npm ERR! Exit status 1
+npm ERR!
+npm ERR! Failed at the @contrast/distringuish@1.2.0 build script.
+npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
+npm WARN Local package.json exists, but node_modules missing, did you mean to install?
+```
+
+You must set up a compiler: [Compiler Installation](troubleshooting-node.html#compilers)
+
 ## Scenario: I've started my application with the Node agent, but I'm not seeing any results.
 
 Here are a few things you can do:


### PR DESCRIPTION
In preparation for node agent 2.6.0 I cleaned up our docs around yarn.  We no longer rely on python or compilers to install the agent.  However, I moved that stuff to the troubleshooting area.  I also added KoaTestBench as it was missing from sample apps and renamed NodeTestBench to ExpressTestBench.

@kaitlynmortimer mentioned she has to do some manual work to make the new compilers.md available/linked in the troubleshooting steps