### PR TITLE
Clarify that MySQL requires system libraries on all platforms

### DIFF
--- a/content/installation/setup/SystemRequirements.md
+++ b/content/installation/setup/SystemRequirements.md
@@ -9,7 +9,7 @@ The Contrast application for Enterprise on Premises (EOP) includes a Tomcat serv
 
 * System with adequate compute and memory resources based on guidance from our [sizing recommendations](installation-setup.html#size)
 * Adherence to the system requirements specified below
-* Installation of the MySQL run-time libraries (Linux Only)
+* Installation of the MySQL run-time libraries
 
 ## System Requirements
 

--- a/content/installation/setup/installation/InstallingContrast.md
+++ b/content/installation/setup/installation/InstallingContrast.md
@@ -8,7 +8,7 @@ tags: "setup EOP installation installer TeamServer Install4J Logging"
 
 Before installing the Contrast application, you should download and fill out the information worksheets at the bottom of this article. Preparing this information greatly reduces configuration errors.
 
-> **Note:** If installing on Linux, make sure you installed the required MySQL shared libraries. See the section on **Preparing for the Installation** in [System Requirements](installation-setup.html#contrast-reqs) for more information.
+> **Note:** Before you begin, install the required MySQL shared libraries. See the section on **Preparing for the Installation** in [System Requirements](installation-setup.html#contrast-reqs) for more information.
 
 ## Run the Installation
 


### PR DESCRIPTION
TeamServer requires system libraries be installed on Windows, but we claim this step is `Linux Only` in the docs. This PR removes that to avoid confusion.