### PR TITLE
Correct mention to profiler chaining option

### DIFF
--- a/content/troubleshooting/net/issues/AnotherIISProfiler.md
+++ b/content/troubleshooting/net/issues/AnotherIISProfiler.md
@@ -15,5 +15,5 @@ The CLR Profiling API only allows a single agent to be attached to a .NET proces
 
 ## Solution
 
-To resolve the issue, Contrast implemented profiler chaining that allows Contrast to run side-by-side with another profiling tool. To enable profiling, see the `ProfilerChainingEnabled` configuration setting](installation-netconfig.html#overview).
+To resolve the issue, Contrast implemented profiler chaining that allows Contrast to run side-by-side with another profiling tool. To enable profiling, see the [`enable_chaining` configuration setting](installation-netconfig.html).
 


### PR DESCRIPTION
Reference enable_chaining rather than ProfilerChainingEnabled and fix link.
Not sure if an inline code backtick block works inside a link without being able to build.