### PR TITLE
NODE-272 add docs for unix-dgram failure

### DIFF
--- a/content/troubleshooting/node/Node-compilers-troubleshooting.md
+++ b/content/troubleshooting/node/Node-compilers-troubleshooting.md
@@ -16,6 +16,12 @@ From versions 2.0.0 to 2.5.1 of the Node agent, you must have installed:
  * If you can build other modules with C++ bindings like [node-sass](https://www.npmjs.com/package/node-sass) and [sqlite3](https://github.com/mapbox/node-sqlite3), you probably meet all of the requirements for Contrast.
  * The official [Node Docker images](https://hub.docker.com/_/node/) come with all of the prerequisites installed.
 
+## gyp ERR! build error
+
+If you are using a version of the Node agent version between 2.0.0 and 2.5.1, please continue below to the Solutions section. If you are using a Node agent version newer than 2.5.1, then the error will most likely be from a module called `unix-dgram`. This module is an optional dependency of the Node Agent and is not essential for functionality. As of version 2.5.1 of the Node Agent, you no longer require a C++ compiler toolchain and this error can be safely ignored.
+
+If this error is still concerning to you or is causing a pipeline to fail for some reason, you can install the node agent with the `--no-optional` npm install flag: `npm install node_contrast-x.y.z.tgz --no-save --no-optional`.
+
 ## Solutions
 
 ### Windows

--- a/content/troubleshooting/node/Node-compilers-troubleshooting.md
+++ b/content/troubleshooting/node/Node-compilers-troubleshooting.md
@@ -18,9 +18,15 @@ From versions 2.0.0 to 2.5.1 of the Node agent, you must have installed:
 
 ## gyp ERR! build error
 
-If you are using a version of the Node agent version between 2.0.0 and 2.5.1, please continue below to the Solutions section. If you are using a Node agent version newer than 2.5.1, then the error will most likely be from a module called `unix-dgram`. This module is an optional dependency of the Node Agent and is not essential for functionality. As of version 2.5.1 of the Node Agent, you no longer require a C++ compiler toolchain and this error can be safely ignored.
+If you're using a version of the Node agent between 2.0.0 and 2.5.1, continue to the **Solutions** section. 
 
-If this error is still concerning to you or is causing a pipeline to fail for some reason, you can install the node agent with the `--no-optional` npm install flag: `npm install node_contrast-x.y.z.tgz --no-save --no-optional`.
+If you're using a Node agent version newer than 2.5.1, the error will most likely be from a module called `unix-dgram`. This module is an optional dependency of the agent and isn't essential for functionality. As of version 2.5.1, the agent no longer requires a C++ compiler toolchain, and you can safely ignore this error.
+
+If this error is still concerning to you or is causing a pipeline to fail, you can install the Node agent with the `--no-optional` npm install flag: 
+
+```
+npm install node_contrast-x.y.z.tgz --no-save --no-optional
+```
 
 ## Solutions
 


### PR DESCRIPTION
unix-dgram is an optional dependency of the Node agent and is not essential to its functionality. We have been responding to this problem on a case-by-case basis, but we want to get it out in the open.