### PR TITLE
DOTNET-738: Add note about requiring .NET Core Runtime 2.1.3 or greater

### DIFF
--- a/content/installation/netcore/install/Supported-technology-netcore.md
+++ b/content/installation/netcore/install/Supported-technology-netcore.md
@@ -93,6 +93,8 @@ The .NET Core agent supports the following technologies:
 | .NET Core Runtime          | 2.1.X, 2.2.X                             |
 | .NET Core Target           | 2.1 (netcoreapp2.1), 2.2 (netcoreapp2.2) |
 
+> **Note:** .NET Core 2.1.X support requires .NET Core Runtime 2.1.3 or higher due to [a bug in the .NET Core profiling API](https://github.com/dotnet/coreclr/issues/18448).
+
 The agent does **not** support the following technologies at this time:
 
 * Self-contained deployments


### PR DESCRIPTION
Due a bug in the profiling api we require atleast 2.1.3 .NET Core runtime