### PR TITLE
Updated system requirements ubuntu setup, min 16.04, recommended 18.04

### DIFF
--- a/content/installation/setup/SystemRequirements.md
+++ b/content/installation/setup/SystemRequirements.md
@@ -16,7 +16,7 @@ The Contrast application for Enterprise on Premises (EOP) includes a Tomcat serv
 | Category            | Minimum   | Recommended | Description |
 | :------------------ | :-------- | :---------- | :---------- |
 | **OS Architecture** | 64-bit | 64-bit | Due to memory requirements, the Contrast application can **only** run on 64-bit architectures. |
-| **Operating System** | <ul><li>Microsoft Windows 2012 R2</li> <li>Ubuntu 12.04 LTS</li><li>Centos 6</li></ul> | <ul><li>Microsoft Windows 2012 R2  </li><li>  Ubuntu 14.04 LTS </li><li> Centos 7</li></ul>| Any modern Operating System **should** run Contrast. Contrast officially supports the following: <ul><li>Ubuntu Linux </li><li> Debian Linux </li><li> Redhat Enterprise Linux </li><li> Centos Linux </li><li> Windows 2012 R2 </li> |
+| **Operating System** | <ul><li>Microsoft Windows 2012 R2</li> <li>Ubuntu 16.04 LTS</li><li>Centos 6</li></ul> | <ul><li>Microsoft Windows 2012 R2  </li><li>  Ubuntu 18.04 LTS </li><li> Centos 7</li></ul>| Any modern Operating System **should** run Contrast. Contrast officially supports the following: <ul><li>Ubuntu Linux </li><li> Debian Linux </li><li> Redhat Enterprise Linux </li><li> Centos Linux </li><li> Windows 2012 R2 </li> |
 | **Java** | 1.8 | 1.8 | |
 | **MySQL** | 5.7 | 5.7.23 | Contrast currently runs 5.7.23 in AWS. Contrast doesn't anticipate any issues if you run a different build of MySQL 5.7; if you do experience an issue, please open a Support ticket.  MySQL versions 8 and higher are currently **not** supported |
 
@@ -26,7 +26,7 @@ To run Contrast, you must preconfigure your base operating system with a shared 
 Customers running **Centos** or **RHL**:
 
 ````
-[contrast@myserver ~]# yum install libaio 
+[contrast@myserver ~]# yum install libaio
 ````
 
 Customers running **Ubuntu** or **Debian**:


### PR DESCRIPTION
A couple of OS Ubuntu System Changes:

- Ubuntu 12.04 was end of life in April 2017
- Ubuntu 14.04 is coming end of life, and has ended standard support
- Ubuntu 16.04 is minimum standard support OS
- SaaS currently runs behind Ubuntu 18.04, so bumping it into the recommended, to be in line with the other documentation