### PR TITLE
Update installation docs for Python assess beta

### DIFF
--- a/content/installation/python/PythonConfig.md
+++ b/content/installation/python/PythonConfig.md
@@ -22,7 +22,7 @@ The agent and service may share a common configuration file, but only some optio
 
 ### Enable the agent 
 
-* **enable**: Set to `false` to disable the agent. Defaults to `true` if not present.
+* **enable**: Only set this property if you want to turn off Contrast. Set to `true` to turn the agent on; set to `false` to turn the agent off.
 
 ### Contrast UI properties
 
@@ -56,7 +56,7 @@ Define the following properties to set logging values. If these properties aren'
 
 * **agent**: Options for communicating between the agent and the service
   * **logger**:
-    * **path**: Enable diagnostic logging by setting a path to a log file. While diagnostic logging hurts performance, it generates useful information for debugging Contrast. The value set here is the location to which the agent saves log output. If no log file exists at this location, the agent creates a file. Use `STDOUT` to log to `stdout` instead. <br> Example - */opt/Contrast/contrast.log* creates a log in the */opt/Contrast* directory, and rotates it automatically as needed.
+    * **path**: Enable diagnostic logging by setting a path to a log file. While diagnostic logging hurts performance, it generates useful information for debugging Contrast. The value set here is the location to which the agent saves log output. If no log file exists at this location, the agent creates a file. <br> Example - */opt/Contrast/contrast.log* creates a log in the */opt/Contrast* directory, and rotates it automatically as needed.
     * **level**: Set the the log output level. Value options are `ERROR`, `WARN`, `INFO`, and `DEBUG`.
     * **progname**: Set the name the agent uses to identify the process within the log file <br> Example: Contrast Agent
 
@@ -90,17 +90,17 @@ Define the following properties to set Syslog values. If the properties aren't d
 The following properties are used by the Contrast Service.
 
 * **service**: 
-  * **enable**: Set to `false` to prevent the agent from automatically starting the service. This is necessary when connecting to a standalone instance of the service. Defaults to `true`.
-  * **socket**: If this property is defined, and `enable` is set to `true`, the service will be started on a Unix socket at the defined path. Not compatible with the use of `host` and/or `port`. <br> Example: /tmp/service.sock
-  * **host**: If `enable` is `true`, bind the service to this hostname. Otherwise, connect to an external service at this hostname. Defaults to `localhost`. Not compatible with `socket`. <br> Example: `localhost`
-  * **port**: If `enable` is `true`, bind the service to this port. Otherwise, connect to an external service on this port. Defaults to `30555`. Not compatible with `socket`. <br> Example: `30555`
+  * **enable**: Set to `false` to disallow the service to be started, and effectively disable the agent, if read by the service. If the agent reads this property, it disallows service auto-start.
+  * **socket**: If this property is defined, the service is listening on a Unix socket at the defined path. <br> Example: /tmp/service.sock
+  * **host**: Set the the hostname or IP address of the Contrast service to which the Contrast agent should report. **Required.** <br> Example: `localhost`
+  * **port**: Set the the port of the Contrast service to which the Contrast agent should report. **Required.** <br> Example: `30555`
     
 ##### Logger
 
 The following properties are used by the logger in the Contrast service. If the properties are not defined, the service uses the logging values from the Contrast UI.
 
   * **logger**:
-    * **path**: Set the location to which the Contrast service saves log output. If no log file exists at this location, the service creates one. If the value is `STDOUT`, log to `stdout`. <br> Example: */opt/Contrast/contrast_service.log* will create a log in the */opt/Contrast* directory.
+    * **path**: Set the location to which the Contrast service saves log output. If no log file exists at this location, the service creates one. <br> Example: */opt/Contrast/contrast_service.log* will create a log in the */opt/Contrast* directory.
     * **level**: Set the the log output level. Value options are `ERROR`, `WARN`, `INFO`, and `DEBUG`.
     * **progname**: Set the name the agent uses to identify the process within the service log file <br> Example: Contrast Agent
 
@@ -119,7 +119,7 @@ Use the properties in this section to override the inventory features.
 Use the properties in this section to override Protect features.
 
 * **protect**:
-  * **enable**: Use the properties in this section to determine if the Protect feature should be enabled. If this property is not present, the decision is delegated to the Contrast UI.
+  * **enable**: Use the properties in this section to determine if the Protect feature should be enabled. If this property is not present, the decision is delegated to the Contrast UI. 
   * **rules**:
     * **disabled_rules**: Define a list of Protect rules to disable in the agent. The rules must be formatted as a comma-delimited list.
     * **bot-blocker**: 
@@ -137,7 +137,7 @@ Use the properties in this section to override Protect features.
     * **xxe**:
       * **mode**: Set the mode of the rule. Value options are `monitor`, `block`, `block_at_perimeter`, or `off`. <br> Note: If a setting says, "if blocking is enabled", the setting can be `block` or `block_at_perimeter`.
 
-### Contrast Protect properties
+### Contrast Assess properties
 
 Use the properties in this section to override Assess features (beta).
 

--- a/content/installation/python/PythonConfig.md
+++ b/content/installation/python/PythonConfig.md
@@ -22,7 +22,7 @@ The agent and service may share a common configuration file, but only some optio
 
 ### Enable the agent 
 
-* **enable**: Only set this property if you want to turn off Contrast. Set to `true` to turn the agent on; set to `false` to turn the agent off.
+* **enable**: Set to `false` to disable the agent. Defaults to `true` if not present.
 
 ### Contrast UI properties
 
@@ -56,7 +56,7 @@ Define the following properties to set logging values. If these properties aren'
 
 * **agent**: Options for communicating between the agent and the service
   * **logger**:
-    * **path**: Enable diagnostic logging by setting a path to a log file. While diagnostic logging hurts performance, it generates useful information for debugging Contrast. The value set here is the location to which the agent saves log output. If no log file exists at this location, the agent creates a file. <br> Example - */opt/Contrast/contrast.log* creates a log in the */opt/Contrast* directory, and rotates it automatically as needed.
+    * **path**: Enable diagnostic logging by setting a path to a log file. While diagnostic logging hurts performance, it generates useful information for debugging Contrast. The value set here is the location to which the agent saves log output. If no log file exists at this location, the agent creates a file. Use `STDOUT` to log to `stdout` instead. <br> Example - */opt/Contrast/contrast.log* creates a log in the */opt/Contrast* directory, and rotates it automatically as needed.
     * **level**: Set the the log output level. Value options are `ERROR`, `WARN`, `INFO`, and `DEBUG`.
     * **progname**: Set the name the agent uses to identify the process within the log file <br> Example: Contrast Agent
 
@@ -90,17 +90,17 @@ Define the following properties to set Syslog values. If the properties aren't d
 The following properties are used by the Contrast Service.
 
 * **service**: 
-  * **enable**: Set to `false` to disallow the service to be started, and effectively disable the agent, if read by the service. If the agent reads this property, it disallows service auto-start.
-  * **socket**: If this property is defined, the service is listening on a Unix socket at the defined path. <br> Example: /tmp/service.sock
-  * **host**: Set the the hostname or IP address of the Contrast service to which the Contrast agent should report. **Required.** <br> Example: `localhost`
-  * **port**: Set the the port of the Contrast service to which the Contrast agent should report. **Required.** <br> Example: `30555`
+  * **enable**: Set to `false` to prevent the agent from automatically starting the service. This is necessary when connecting to a standalone instance of the service. Defaults to `true`.
+  * **socket**: If this property is defined, and `enable` is set to `true`, the service will be started on a Unix socket at the defined path. Not compatible with the use of `host` and/or `port`. <br> Example: /tmp/service.sock
+  * **host**: If `enable` is `true`, bind the service to this hostname. Otherwise, connect to an external service at this hostname. Defaults to `localhost`. Not compatible with `socket`. <br> Example: `localhost`
+  * **port**: If `enable` is `true`, bind the service to this port. Otherwise, connect to an external service on this port. Defaults to `30555`. Not compatible with `socket`. <br> Example: `30555`
     
 ##### Logger
 
 The following properties are used by the logger in the Contrast service. If the properties are not defined, the service uses the logging values from the Contrast UI.
 
   * **logger**:
-    * **path**: Set the location to which the Contrast service saves log output. If no log file exists at this location, the service creates one. <br> Example: */opt/Contrast/contrast_service.log* will create a log in the */opt/Contrast* directory.
+    * **path**: Set the location to which the Contrast service saves log output. If no log file exists at this location, the service creates one. If the value is `STDOUT`, log to `stdout`. <br> Example: */opt/Contrast/contrast_service.log* will create a log in the */opt/Contrast* directory.
     * **level**: Set the the log output level. Value options are `ERROR`, `WARN`, `INFO`, and `DEBUG`.
     * **progname**: Set the name the agent uses to identify the process within the service log file <br> Example: Contrast Agent
 
@@ -119,7 +119,7 @@ Use the properties in this section to override the inventory features.
 Use the properties in this section to override Protect features.
 
 * **protect**:
-  * **enable**: Use the properties in this section to determine if the Protect feature should be enabled. If this property is not present, the decision is delegated to the Contrast UI. 
+  * **enable**: Use the properties in this section to determine if the Protect feature should be enabled. If this property is not present, the decision is delegated to the Contrast UI.
   * **rules**:
     * **disabled_rules**: Define a list of Protect rules to disable in the agent. The rules must be formatted as a comma-delimited list.
     * **bot-blocker**: 
@@ -137,6 +137,12 @@ Use the properties in this section to override Protect features.
     * **xxe**:
       * **mode**: Set the mode of the rule. Value options are `monitor`, `block`, `block_at_perimeter`, or `off`. <br> Note: If a setting says, "if blocking is enabled", the setting can be `block` or `block_at_perimeter`.
 
+### Contrast Protect properties
+
+Use the properties in this section to override Assess features (beta).
+
+* **assess**:
+  * **enable**: Set to `true` to enable or `false` to disable. Default behavior is delegated to Contrast UI. Note that `protect` and `assess` cannot be enabled at the same time.
 
 ### Application properties
 

--- a/content/installation/python/PythonInstall.md
+++ b/content/installation/python/PythonInstall.md
@@ -8,16 +8,28 @@ tags: "python agent installation"
 To install the Contrast agent into your Python application, you must complete the following steps.  
 
 1. Add the <i>contrast-python-agent-[version].tar.gz</i> to the application's <i>requirements.txt</i>. (This is outlined in the <b>Setup</b> section below.)
-2. Add the *contrast_security.yaml* file to the application's top directory. (This is outlined in the **Configuration** section below.)
-3. Run the Contrast Service as a standalone service on the same server as the application. (This is outlined in the section below to **Run the Service**.)
+2. Add the *contrast_security.yaml* file to the application's working directory. (This is outlined in the **Configuration** section below.)
+3. (*Optional*) Start a standalone instance of the Contrast Service. By default, the service is started automatically by the agent when your application starts.
+   For more details on running the standalone service, see the [Contrast Service documentation](installation-service.html#service-overview).
+
 
 ## Setup
 
-The <i>contrast-python-agent-[version].tar.gz</i> is a standard packaged Python library that you can add to the application's *requirements.txt*.
+The <i>contrast-python-agent-[version].tar.gz</i> is a Python package that can be installed using `pip`.
+
+### Requirements
+
+Starting with version 2.3.0 of the agent, the package installation step
+requires the compilation of C extensions. This process is automatic, but it
+requires certain software to be installed in the target environment.
+
+* At a minimum, `gcc`, `make`, `automake` and `autoconf` are required. Please note that the
+  package names may be different on different platforms. It may be useful to install your platform's equivalent of `build-essential`.
+* On some lightweight platforms it may be necessary to install system headers.
 
 ### Contrast as a Python Package
 
-To use Contrast, add this line to your application's *requirements.txt* after downloading the agent:
+To use Contrast, add this line to your application's `requirements.txt` (usually found at the top level of the application source tree) after downloading the agent:
 
 ``` python
 ./path/to/contrast-python-agent-[version].tar.gz
@@ -39,39 +51,81 @@ pip install ./path/to/contrast-python-agent-[version].tar.gz
 
 ### Middleware inclusion
 
-To hook into incoming requests and outbound responses, you need to add a middleware to your application. To add the middleware to your application, use the appropriate guidance for your framework. 
+Middleware is the name for a software component that is part of a web
+application application and is capable of reading and modifying inbound
+requests and outbound responses.
+
+The Contrast Python Agent is implemented as a middleware for all of the
+frameworks that we support. In order to use the agent, the middleware must be
+configured for the framework that your application uses. Specific instructions
+for each of the supported frameworks are below.
 
 #### Django 
 
-For Django 1.10+ and 2.0+, add the following in your *settings.py* file:
+Django middleware is configured in the *settings.py* file. This file is not
+found in the same location for all applications, but it is generally near the
+top of the application source tree. Common locations include:
+
+* `<appname>/settings.py`
+* `config/settings.py`
+* `app/settings.py`
+
+>**Note:** When searching the source tree to find the *settings.py*, make sure
+to exclude any directories that correspond to Python virtual environments.
+
+Some applications have multiple *settings.py* files, which may correspond to
+different configurations of the app (e.g. prod, test, etc.). In those cases,
+add the Contrast Agent middleware to any/all of the configurations where it
+will be used.
+
+For Django 1.10+ and 2.0+, look for the `MIDDLEWARE` configuration variable,
+which is an array. Add the Contrast Agent module to the list, like shown below:
 
 ``` python
 MIDDLEWARE = [
+  'contrast.agent.middlewares.django_middleware.DjangoMiddleware',
   # OTHER MIDDLEWARE,
-  'contrast.agent.middlewares.django_middleware.DjangoMiddleware'
 ]
 ```
 
-Older versions of Django have a different architecture for middlewares. For Django 1.6 to 1.9, add the following in your *settings.py* file:
+In general, it is best for the Contrast middleware to be included as early in
+the list as is possible, although modifying the order may be necessary to get
+the app working in some circumstances.
+
+Older versions of Django have a different architecture for middlewares. For
+Django 1.6 to 1.9, look for the `MIDDLEWARE_CLASSES` configuration variable
+in *settings.py*.
 
 ``` python
 MIDDLEWARE_CLASSES = [
-  # OTHER MIDDLEWARE,
-  'contrast.agent.middlewares.legacy_django_middleware.DjangoMiddleware'
+  'contrast.agent.middlewares.legacy_django_middleware.DjangoMiddleware',
+  # OTHER MIDDLEWARE
 ]
 ```
 
+See the [Django
+documentation](https://docs.djangoproject.com/en/2.2/topics/http/middleware/)
+for more details on middleware inclusion.
+
 #### Flask 
+
+Flask middleware is a WSGI middleware which operates by wrapping the flask application instance. The following shows an example flask application which is wrapped by the Contrast
+middleware class:
 
 ``` python
 import Flask
 
+# This line imports the Contrast middleware class from the package
 from contrast.agent.middlewares.flask_middleware import FlaskMiddleware as ContrastMiddleware
 
+# This is where the example app is declared. Look for something similar in your
+# application since this instance needs to be wrapped by Contrast middleware
 app = Flask(__name__)
 
+# This line wraps the application instance with the Contrast middleware
 app.wsgi_app = ContrastMiddleware(app)
 
+# Everything below this line is part of the example app. It should not be added
 @app.route('/')
 def index():
     return render_template('index.html')
@@ -80,7 +134,14 @@ if __name__ == '__main__':
     app.run(...)
 ```
 
+See the [Flask
+documentation](https://flask.palletsprojects.com/en/1.1.x/quickstart/#hooking-in-wsgi-middleware)
+for more details on using WSGI middleware.
+
 #### Pyramid
+
+In Pyramid, middlewares are called "tweens". See the example below for adding
+the Contrast middleware to a Pyramid app:
 
 ``` python
 from pyramid.config import Configurator
@@ -89,28 +150,55 @@ config = Configurator()
 config.add_tween('contrast.agent.middlewares.pyramid_middleware.PyramidMiddleware')
 ```
 
+See the [Pyramid
+documentation](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html#explicit-tween-configuration)
+for additional details on tween configuration.
+
 #### WSGI
 
+WSGI middleware is implemented as a class that wraps the application instance.
+(This is the basis for both Flask and Pylons middleware as well.)
+
 ``` python
+# This line imports the Contrast middleware class from the package
 from contrast.agent.middlewares.wsgi_middleware import WSGIMiddleware as ContrastMiddleware
 
 # other app code
 
 app = get_wsgi_application()
 
+# This line wraps the application instance with the Contrast middleware
 app = ContrastMiddleware(app)
 ```
 
+See the [WSGI spec](https://www.python.org/dev/peps/pep-0333/#middleware-components-that-play-both-sides)
+for additional details on WSGI middleware.
+
 #### Pylons
+
+Like Flask, Pylons middleware is WSGI middleware, which means the
+middleware class is used to wrap the application instance:
 
 ``` python
 from pylons.wsgiapp import PylonsApp
+# This line imports the Contrast middleware class from the package
 from contrast.agent.middlewares.wsgi_middleware import WSGIMiddleware as ContrastMiddleware
  
 app = PylonsApp()
+# This line wraps the application instance with the Contrast middleware
 app = ContrastMiddleware(app)
 ```
 
 ## Next Steps
 
-Once the installation process is complete, you can update the agent's [configuration](installation-pythonconfig.html) file. 
+Once the installation process is complete, you can update the agent's [configuration](installation-pythonconfig.html) file.
+
+## Troubleshooting
+
+* For version 2.3.0 of the agent and earlier, when starting the bundled service using the `host`/`port` configuration, it is necessary for the `port` value to be given explicitly. A useful default is `30555`. An alternative us to use the `socket` configuration instead.
+
+* There may be installation issues when using older versions of `pip`. It may be useful to try to update to the latest version by running `pip install --upgrade pip`.
+
+* There may be conflicts between the versions of app dependencies and agent dependencies. In these cases, it is important to make sure that all app dependencies are installed before installing the agent.
+
+* On Linux, the dependency `psutil` requires `linux/ethtool.h` to be installed, so it may be necessary to install the `ethtool` package for your system if this fails.

--- a/content/installation/python/PythonInstall.md
+++ b/content/installation/python/PythonInstall.md
@@ -192,13 +192,3 @@ app = ContrastMiddleware(app)
 ## Next Steps
 
 Once the installation process is complete, you can update the agent's [configuration](installation-pythonconfig.html) file.
-
-## Troubleshooting
-
-* For version 2.3.0 of the agent and earlier, when starting the bundled service using the `host`/`port` configuration, it is necessary for the `port` value to be given explicitly. A useful default is `30555`. An alternative us to use the `socket` configuration instead.
-
-* There may be installation issues when using older versions of `pip`. It may be useful to try to update to the latest version by running `pip install --upgrade pip`.
-
-* There may be conflicts between the versions of app dependencies and agent dependencies. In these cases, it is important to make sure that all app dependencies are installed before installing the agent.
-
-* On Linux, the dependency `psutil` requires `linux/ethtool.h` to be installed, so it may be necessary to install the `ethtool` package for your system if this fails.

--- a/content/installation/python/PythonInstall.md
+++ b/content/installation/python/PythonInstall.md
@@ -7,35 +7,26 @@ tags: "python agent installation"
 
 To install the Contrast agent into your Python application, you must complete the following steps.  
 
-1. Add the <i>contrast-python-agent-[version].tar.gz</i> to the application's <i>requirements.txt</i>. (This is outlined in the <b>Setup</b> section below.)
-2. Add the *contrast_security.yaml* file to the application's working directory. (This is outlined in the **Configuration** section below.)
-3. (*Optional*) Start a standalone instance of the Contrast Service. By default, the service is started automatically by the agent when your application starts.
-   For more details on running the standalone service, see the [Contrast Service documentation](installation-service.html#service-overview).
+* Add the <i>contrast-python-agent-[version].tar.gz</i> to the application's <i>requirements.txt</i>. (This is outlined in the <b>Setup</b> section below.)
+* Add the *contrast_security.yaml* file to the application's working directory. (This is outlined in the **Configuration** section below.)
 
+You may also start a standalone instance of the Contrast Service. By default, the service is started automatically by the agent when your application starts. For more details on running the standalone service, see the [Contrast Service documentation](installation-service.html#service-overview).
+
+See [Supported Technologies](installation-python.html#python-supported) for more requirements. 
 
 ## Setup
 
 The <i>contrast-python-agent-[version].tar.gz</i> is a Python package that can be installed using `pip`.
 
-### Requirements
-
-Starting with version 2.3.0 of the agent, the package installation step
-requires the compilation of C extensions. This process is automatic, but it
-requires certain software to be installed in the target environment.
-
-* At a minimum, `gcc`, `make`, `automake` and `autoconf` are required. Please note that the
-  package names may be different on different platforms. It may be useful to install your platform's equivalent of `build-essential`.
-* On some lightweight platforms it may be necessary to install system headers.
-
 ### Contrast as a Python Package
 
-To use Contrast, add this line to your application's `requirements.txt` (usually found at the top level of the application source tree) after downloading the agent:
+To use Contrast, add the following line to your application's *requirements.txt* (usually found at the top level of the application source tree) after downloading the agent:
 
 ``` python
 ./path/to/contrast-python-agent-[version].tar.gz
 ```
 
-After editing the *requirements.txt* you can install normally with:
+After editing the *requirements.txt*, you can install normally:
 
 ``` bash
 pip install -r requirements.txt
@@ -51,35 +42,23 @@ pip install ./path/to/contrast-python-agent-[version].tar.gz
 
 ### Middleware inclusion
 
-Middleware is the name for a software component that is part of a web
-application application and is capable of reading and modifying inbound
-requests and outbound responses.
+Middleware is the name for a software component that's part of a web application, and is capable of reading and modifying inbound requests and outbound responses.
 
-The Contrast Python Agent is implemented as a middleware for all of the
-frameworks that we support. In order to use the agent, the middleware must be
-configured for the framework that your application uses. Specific instructions
-for each of the supported frameworks are below.
+The Python agent is implemented as a middleware for all of the frameworks that Contrast supports. To use the agent, you must configure the middleware for the framework that your application uses. Specific instructions for each of the supported frameworks are below.
 
 #### Django 
 
-Django middleware is configured in the *settings.py* file. This file is not
-found in the same location for all applications, but it is generally near the
-top of the application source tree. Common locations include:
+Django middleware is configured in the *settings.py* file. This file isn't found in the same location for all applications, but it's generally near the top of the application source tree. Common locations include:
 
-* `<appname>/settings.py`
-* `config/settings.py`
-* `app/settings.py`
+* *<appname>/settings.py*
+* *config/settings.py*
+* *app/settings.py*
 
->**Note:** When searching the source tree to find the *settings.py*, make sure
-to exclude any directories that correspond to Python virtual environments.
+>**Note:** When searching the source tree to find the *settings.py*, make sure to exclude any directories that correspond to Python virtual environments.
 
-Some applications have multiple *settings.py* files, which may correspond to
-different configurations of the app (e.g. prod, test, etc.). In those cases,
-add the Contrast Agent middleware to any/all of the configurations where it
-will be used.
+Some applications have multiple *settings.py* files, which may correspond to different configurations of the application (e.g., prod or test). In these cases, add the Contrast agent middleware to any and all of the configurations where it will be used.
 
-For Django 1.10+ and 2.0+, look for the `MIDDLEWARE` configuration variable,
-which is an array. Add the Contrast Agent module to the list, like shown below:
+For Django 1.10+ and 2.0+, look for the `MIDDLEWARE` configuration variable, which is an array. Add the Contrast agent module to the list, as shown:
 
 ``` python
 MIDDLEWARE = [
@@ -88,13 +67,9 @@ MIDDLEWARE = [
 ]
 ```
 
-In general, it is best for the Contrast middleware to be included as early in
-the list as is possible, although modifying the order may be necessary to get
-the app working in some circumstances.
+In general, it's best practice to include the Contrast middleware as early in the list as is possible; although modifying the order may be necessary to get the application working in some circumstances.
 
-Older versions of Django have a different architecture for middlewares. For
-Django 1.6 to 1.9, look for the `MIDDLEWARE_CLASSES` configuration variable
-in *settings.py*.
+Older versions of Django have a different architecture for middlewares. For Django 1.6 to 1.9, look for the `MIDDLEWARE_CLASSES` configuration variable in *settings.py*.
 
 ``` python
 MIDDLEWARE_CLASSES = [
@@ -103,14 +78,11 @@ MIDDLEWARE_CLASSES = [
 ]
 ```
 
-See the [Django
-documentation](https://docs.djangoproject.com/en/2.2/topics/http/middleware/)
-for more details on middleware inclusion.
+See the [Django documentation](https://docs.djangoproject.com/en/2.2/topics/http/middleware/) for more details on middleware inclusion.
 
 #### Flask 
 
-Flask middleware is a WSGI middleware which operates by wrapping the flask application instance. The following shows an example flask application which is wrapped by the Contrast
-middleware class:
+Flask middleware is a WSGI middleware which operates by wrapping the Flask application instance. The following example shows a sample Flask application wrapped by the Contrast middleware class:
 
 ``` python
 import Flask
@@ -134,14 +106,11 @@ if __name__ == '__main__':
     app.run(...)
 ```
 
-See the [Flask
-documentation](https://flask.palletsprojects.com/en/1.1.x/quickstart/#hooking-in-wsgi-middleware)
-for more details on using WSGI middleware.
+See the [Flask documentation](https://flask.palletsprojects.com/en/1.1.x/quickstart/#hooking-in-wsgi-middleware) for more details on using WSGI middleware.
 
 #### Pyramid
 
-In Pyramid, middlewares are called "tweens". See the example below for adding
-the Contrast middleware to a Pyramid app:
+In Pyramid, middlewares are called "tweens". See the example below for adding the Contrast middleware to a Pyramid application:
 
 ``` python
 from pyramid.config import Configurator
@@ -150,14 +119,11 @@ config = Configurator()
 config.add_tween('contrast.agent.middlewares.pyramid_middleware.PyramidMiddleware')
 ```
 
-See the [Pyramid
-documentation](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html#explicit-tween-configuration)
-for additional details on tween configuration.
+See the [Pyramid documentation](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html#explicit-tween-configuration) for additional details on tween configuration.
 
 #### WSGI
 
-WSGI middleware is implemented as a class that wraps the application instance.
-(This is the basis for both Flask and Pylons middleware as well.)
+WSGI middleware is implemented as a class that wraps the application instance. (This is also the basis for both Flask and Pylons middleware.)
 
 ``` python
 # This line imports the Contrast middleware class from the package
@@ -171,13 +137,11 @@ app = get_wsgi_application()
 app = ContrastMiddleware(app)
 ```
 
-See the [WSGI spec](https://www.python.org/dev/peps/pep-0333/#middleware-components-that-play-both-sides)
-for additional details on WSGI middleware.
+See the [WSGI spec](https://www.python.org/dev/peps/pep-0333/#middleware-components-that-play-both-sides) for additional details on WSGI middleware.
 
 #### Pylons
 
-Like Flask, Pylons middleware is WSGI middleware, which means the
-middleware class is used to wrap the application instance:
+Like Flask, Pylons middleware is WSGI middleware which operates by wrapping the Flask application instance: 
 
 ``` python
 from pylons.wsgiapp import PylonsApp

--- a/content/installation/python/PythonOverview.md
+++ b/content/installation/python/PythonOverview.md
@@ -4,35 +4,24 @@ description: "About the Python agent"
 tags: "installation python agent overview"
 -->
 
-The Contrast Python agent provides runtime protection of Django, Flask and
-Pyramid web applications.
+The Contrast Python agent provides runtime protection of Django, Flask and Pyramid web applications.
 
-Version 2.3.0 of the agent introduces beta Assess functionality. This provides
-the ability to find vulnerabilities in applications before they can be
-exploited.
+Version 2.3.0 of the agent introduces beta Assess functionality. This provides the ability to find vulnerabilities in applications before they can be exploited.
 
->**Note:** The beta Assess feature can only be licensed in specific instances
-of the Contrast UI.
+>**Note:** The beta Assess feature can only be licensed in specific instances of the Contrast UI.
 
 ## About Python 
 
 The Python agent is a WSGI- and framework-specific middleware that's compatible with the most-popular web application frameworks. The agent's goal is to be fully WSGI compatible along with other web frameworks. 
 
-In Protect mode the Python agent inspects HTTP requests to identify potentially harmful input vectors. During the request, the agent inspects database queries, file writes and other potentially damaging actions resulting from the request. At the end of the request, the agent inspects the rendered output for successful attacks, and can block a successful attack from being forwarded to the application user. The service sends the details of the attack to the Contrast application, which then sends you an alert and displays attack details in the interface.
+In Protect mode, the Python agent inspects HTTP requests to identify potentially harmful input vectors. During the request, the agent inspects database queries, file writes and other potentially damaging actions resulting from the request. At the end of the request, the agent inspects the rendered output for successful attacks, and can block a successful attack from being forwarded to the application user. The service sends the details of the attack to the Contrast application, which then sends you an alert and displays attack details in the interface.
 
-In Assess mode (beta) the agent identifies vulnerable dataflow paths and other issues during normal execution of your application. It reports these findings so that the vulnerabilities can be remediated before the app is deployed in a live environment.
+In Assess mode, the agent identifies vulnerable dataflow paths and other issues during normal execution of your application. It reports these findings to your organization in the Contrast UI; you can then remediate the vulnerabilities before deploying the application in a live environment.
 
 <a href="assets/images/Python-agent-arch.png" rel="lightbox" title="Python agent architecture"><img class="thumbnail" src="assets/images/Python-agent-arch.png"/></a>
 
 ## Use the Agent 
 
-To start protecting your application, download the Python agent and create a
-configuration file as described in [Python Agent
-Installation](installation-python.html#python-install). The Python agent is
-installed as a standard Python package, and uses the Contrast Service to
-communicate results.
+To start using your application with Contrast, download the Python agent and create a configuration file as described in [Python Agent Installation](installation-python.html#python-install). The Python agent is installed as a standard Python package, and uses the Contrast Service to communicate results.
 
-By default, the service is started automatically when your application starts.
-It is also possible to configure the agent to communicates with a standalone
-Contrast Service that runs independently. See the [Contrast Service
-documentation](installation-service.html#service-overview) for more details.
+By default, the service is started automatically when your application starts. It's also possible to configure the agent to communicate with a standalone Contrast Service that runs independently. See the [Contrast Service documentation](installation-service.html#service-overview) for more details.

--- a/content/installation/python/PythonOverview.md
+++ b/content/installation/python/PythonOverview.md
@@ -4,16 +4,35 @@ description: "About the Python agent"
 tags: "installation python agent overview"
 -->
 
-The Contrast Python agent provides runtime protection of Django, Flask and Pyramid web applications. 
+The Contrast Python agent provides runtime protection of Django, Flask and
+Pyramid web applications.
+
+Version 2.3.0 of the agent introduces beta Assess functionality. This provides
+the ability to find vulnerabilities in applications before they can be
+exploited.
+
+>**Note:** The beta Assess feature can only be licensed in specific instances
+of the Contrast UI.
 
 ## About Python 
 
 The Python agent is a WSGI- and framework-specific middleware that's compatible with the most-popular web application frameworks. The agent's goal is to be fully WSGI compatible along with other web frameworks. 
 
-From its position within the middleware stack, the Python agent inspects HTTP requests to identify potentially harmful input vectors. During the request, the agent inspects database queries, file writes and other potentially damaging actions resulting from the request. At the end of the request, the agent inspects the rendered output for successful attacks, and can block a successful attack from being forwarded to the application user. The service sends the details of the attack to the Contrast application, which then sends you an alert and displays attack details in the interface. 
+In Protect mode the Python agent inspects HTTP requests to identify potentially harmful input vectors. During the request, the agent inspects database queries, file writes and other potentially damaging actions resulting from the request. At the end of the request, the agent inspects the rendered output for successful attacks, and can block a successful attack from being forwarded to the application user. The service sends the details of the attack to the Contrast application, which then sends you an alert and displays attack details in the interface.
+
+In Assess mode (beta) the agent identifies vulnerable dataflow paths and other issues during normal execution of your application. It reports these findings so that the vulnerabilities can be remediated before the app is deployed in a live environment.
 
 <a href="assets/images/Python-agent-arch.png" rel="lightbox" title="Python agent architecture"><img class="thumbnail" src="assets/images/Python-agent-arch.png"/></a>
 
 ## Use the Agent 
 
-To start protecting your application, download the Python agent and service, and create a configuration file as described in [Python Agent Installation](installation-python.html#python-install). The Python agent is installed as a standard Python package, and communicates with a standalone Contrast Service that runs outside your application.
+To start protecting your application, download the Python agent and create a
+configuration file as described in [Python Agent
+Installation](installation-python.html#python-install). The Python agent is
+installed as a standard Python package, and uses the Contrast Service to
+communicate results.
+
+By default, the service is started automatically when your application starts.
+It is also possible to configure the agent to communicates with a standalone
+Contrast Service that runs independently. See the [Contrast Service
+documentation](installation-service.html#service-overview) for more details.

--- a/content/installation/python/PythonOverview.md
+++ b/content/installation/python/PythonOverview.md
@@ -8,7 +8,7 @@ The Contrast Python agent provides runtime protection of Django, Flask and Pyram
 
 Version 2.3.0 of the agent introduces beta Assess functionality. This provides the ability to find vulnerabilities in applications before they can be exploited.
 
->**Note:** The beta Assess feature can only be licensed in specific instances of the Contrast UI.
+>**Note:** The beta Assess feature can be licensed in **alpha** and **eval** instances of the Contrast UI.
 
 ## About Python 
 

--- a/content/installation/python/PythonSupportedTechnologies.md
+++ b/content/installation/python/PythonSupportedTechnologies.md
@@ -4,12 +4,14 @@ description: "List of supported technologies"
 tags: "installation Python agent frameworks support package"
 -->
 
-The Python agent supports Python versions 2.7+ and 3.5 to 3.7. Framework support is currently for:
+The Python agent supports Python versions 2.7 and 3.5 to 3.7. Framework support is currently for:
 
 * Django:  1.10+ and 2.0+ <br> (Django 2 is Python 3 only)
-* Flask:   0.10 - 0.12 and 1.0+ 
+* Flask:   0.10 - 0.12 and 1.0+
 * Pyramid: 1.9 (Beta)
 * Pylons: 1.0+
+
+Only Django is officially supported for the beta release of the Assess feature.
 
 >**Note:** The Python agent is meant to be WSGI compatible. It may be compatible to other WSGI applications as long as the guidelines are followed.
 
@@ -17,7 +19,7 @@ The Python agent supports Python versions 2.7+ and 3.5 to 3.7. Framework support
 ## Database Support
 
 The Python Agent has database support for:
- 
+
 * MySQL (`MySQLdb`)
 * Oracle (`cx_Oracle`)
 * SQLite3 (`sqlite3` and `pysqlite2`)
@@ -32,12 +34,18 @@ The Python Agent has NoSQL support for:
 ## Database Support
 
 The Python Agent has ORM support for:
- 
+
 * SQLAlchemy (`SQLAlchemy`)
 * Flask-SQLAlchemy (`Flask-SQLAlchemy`)
 
 ## OS Support
 
-Agent testing is done on **64-bit OSX** and **64-bit Linux**. The agent has no *C* dependencies, and may work in other operating system environments.
+Agent testing is done on **64-bit OSX** and **64-bit Linux**.
 
+Starting with version 2.3.0 of the agent, the package installation step
+requires the compilation of C extensions. This process is automatic, but it
+requires certain software to be installed in the target environment.
 
+* At a minimum, `gcc`, `make`, `automake` and `autoconf` are required. Please note that the
+  package names may be different on different platforms. It may be useful to install your platform's version of `build-essential`.
+* On some platforms, it may be necessary to install system headers.

--- a/content/installation/python/PythonSupportedTechnologies.md
+++ b/content/installation/python/PythonSupportedTechnologies.md
@@ -6,19 +6,19 @@ tags: "installation Python agent frameworks support package"
 
 The Python agent supports Python versions 2.7 and 3.5 to 3.7. Framework support is currently for:
 
-* Django:  1.10+ and 2.0+ <br> (Django 2 is Python 3 only)
-* Flask:   0.10 - 0.12 and 1.0+
+* Django: 1.10+ and 2.0+ <br> (Django 2 is available for Python 3 only.)
+* Flask: 0.10 - 0.12 and 1.0+
 * Pyramid: 1.9 (Beta)
 * Pylons: 1.0+
 
-Only Django is officially supported for the beta release of the Assess feature.
-
->**Note:** The Python agent is meant to be WSGI compatible. It may be compatible to other WSGI applications as long as the guidelines are followed.
+>**Notes:** 
+ * Only Django is officially supported for the beta release of **Assess** capability.
+* The Python agent is meant to be WSGI compatible. It may be compatible to other WSGI applications as long as the guidelines are followed.
 
 
 ## Database Support
 
-The Python Agent has database support for:
+The Python agent has database support for:
 
 * MySQL (`MySQLdb`)
 * Oracle (`cx_Oracle`)
@@ -27,13 +27,13 @@ The Python Agent has database support for:
 
 ## NoSQL Support
 
-The Python Agent has NoSQL support for:
+The Python agent has NoSQL support for:
 
 * Mongo (`pymongo`)
 
 ## Database Support
 
-The Python Agent has ORM support for:
+The Python agent has ORM support for:
 
 * SQLAlchemy (`SQLAlchemy`)
 * Flask-SQLAlchemy (`Flask-SQLAlchemy`)
@@ -42,10 +42,7 @@ The Python Agent has ORM support for:
 
 Agent testing is done on **64-bit OSX** and **64-bit Linux**.
 
-Starting with version 2.3.0 of the agent, the package installation step
-requires the compilation of C extensions. This process is automatic, but it
-requires certain software to be installed in the target environment.
+Starting with version 2.3.0 of the agent, the package installation step requires the compilation of C extensions. This process is automatic, but it requires that certain software is installed in the target environment: 
 
-* At a minimum, `gcc`, `make`, `automake` and `autoconf` are required. Please note that the
-  package names may be different on different platforms. It may be useful to install your platform's version of `build-essential`.
+* At a minimum, `gcc`, `make`, `automake` and `autoconf` are required. The package names may be different on different platforms. It may be useful to install your platform's version of `build-essential`.
 * On some platforms, it may be necessary to install system headers.


### PR DESCRIPTION
This PR contains updates to reflect the release of the beta Python Assess feature. It includes:

* wording to acknowledge the beta release of assess
* updates to installation instructions for assess
* updates to system requirements to reflect C extension build
* a troubleshooting section for installation/runtime issues
* improvements to the middleware inclusion sections to help target non-developers
* fix out-of-date wording about running the service
* updates/improvements to configuration of service and logging

It might be easier to pull these changes and read them in a markdown editor rather than try to parse the diffs.

cc @danilito19 @jleo32 @peter-lazorchak