### PR TITLE
Fix Java System Property Example

### DIFF
--- a/content/installation/java/configuration/YAML-properties-java.md
+++ b/content/installation/java/configuration/YAML-properties-java.md
@@ -41,9 +41,12 @@ On Unix/Linux file systems:
 
 You can also set all of the following YAML properties as system properties. Derive the system property key from the YAML by joining every node with a "." until you reach the bottom property. 
 
-> **Example:** If you want to override the `contrast` property, as given below, you can set `-Dcontrast.enable=false` as a system property.
-  * contrast: 
-    * enable: `true`
+> **Example:** If you want to override the URL for the Contrast UI to which the agent reports, as given below, you can set `-Dcontrast.api.url=https://exampele.com/Contrast` as a system property.
+
+```yaml
+api:
+  url: https://example.com/Contrast
+```
 
 
 ## Configuration Options


### PR DESCRIPTION
The example we give for how to specify a Common Config YAML property as a Java system property is wrong. It also uses YAML property `contrast.enable` which no longer exists.

I fixed the example and replaced the `enable` property with `api.url` because it better demonstrates this mechanism.