### PR TITLE
CONTRAST-35862/UX-199 New Vulnerability Management page

### DIFF
--- a/content/admin/org_settings/Application-defaults.md
+++ b/content/admin/org_settings/Application-defaults.md
@@ -22,15 +22,7 @@ Use the multiselect **Policy** field to choose which [Remediation](admin-policym
 
 ### Behavior 
 
-Check the box to **Require administrative approval when closing vulnerabilities** in your organization. In the fields below, choose the statuses and severities of vulnerabilities that should automatically go into a **Pending** state when a user moves to close them. When a user requests to close any qualifying vulnerabilities, Contrast will [notify](admin-orgsettings.html#org-notify) you that your review is needed. 
-
-> **Note:** To qualify for administrative approval, both a status and severity that you selected in this configuration must apply to the vulnerability being closed. 
-
-Each vulnerability status will remain pending until you submit your review of the closure. If you deny the closure of a vulnerability, you must provide a reason for denial; once confirmed, your feedback appears in the vulnerability's **Discussion** tab. If you disable the feature, any pending closures are automatically approved. 
-
-> **Note:** While in a Pending state, the vulnerability's previous status still applies for the purpose of organizational reports and statistics. 
-
-See [Manage Vulnerabilities](user-vulns.html#manage-vuln) for more information about Pending states and workflows. 
+Check the box to **Automatically apply licenses to new applications** in your organization. A status bar shows you how many licenses have been used. Click through to understand the breakdown of your organization's licenses. 
 
 ### Licensing 
 

--- a/content/admin/policy_mgmt/VulnerabilityManagement.md
+++ b/content/admin/policy_mgmt/VulnerabilityManagement.md
@@ -46,6 +46,8 @@ To create a new policy, select the grid tab for the type of policy desired and c
 
 In the **Triggers** section, use the checkboxes to select the time-based and/or route-based trigger. If a time-based trigger is selected, also input the number of days after which the trigger should fire.
 
+>**Note:** Note: Currently for route based auto-verification to work, session metadata needs to be provided when the agent is launched. For example, `branchName=feature/some-new-thing,committer=Jane,repository=Contrast-Java`. See https://docs.contrastsecurity.com/user-vulnerableapps.html#session for more information.
+
 > **Note:** When using a policy with a route-based trigger, it is recommended to also use define a time-based trigger to account for those vulnerabilities which have been remediated in such a way that cannot be associated back to the original finding in Contrast. Typically, these cases only arise when the code was deleted, and therefore cannot be re-exercised, or redefined such that it occurs on a different route.
 
 If multiple policies affect the same vulnerability, the following rules determine Contrast's course of action:

--- a/content/admin/policy_mgmt/VulnerabilityManagement.md
+++ b/content/admin/policy_mgmt/VulnerabilityManagement.md
@@ -10,7 +10,7 @@ Control how remediation happens. Define if vulnerabilities of a certain severity
 
 ## Vulnerability Behavior 
 
-Check the box to **Require administrative approval when closing vulnerabilities** in your organization. In the fields below, choose the statuses and severities of vulnerabilities that should automatically go into a Pending state when a user moves to close them. When a user requests to close any qualifying vulnerabilities, Contrast will [notify](admin-orgsettings.html#org-notify) you that your review is needed.
+Check the box to **Require administrative approval when closing vulnerabilities** in your organization. In the fields below, choose the statuses and severities of vulnerabilities that should automatically go into a **Pending** state when a user moves to close them. When a user requests to close any qualifying vulnerabilities, Contrast will [notify](admin-orgsettings.html#org-notify) you that your review is needed.
 
 <a href="assets/images/Default-vuln-behavior.png" rel="lightbox" title="Define Vulnerability Behavior"><img class="thumbnail" src="assets/images/Default-vuln-behavior.png"/></a>
 
@@ -24,16 +24,15 @@ See [Manage Vulnerabilities](user-vulns.html#manage-vuln) for more information a
 
 ## Vulnerability Policy
 
-Create policies for vulnerabilities in your organization, and Contrast will clean up your view of security risks. As Contrast assesses your applications, it can either flag vulnerabilities that are in violation of the policy or automatically mark them Remediated - Auto-Verified. 
+Create policies for vulnerabilities in your organization, and Contrast will clean up your view of security risks. As Contrast assesses your applications, it can either flag vulnerabilities that are in violation of the policy or automatically mark them **Remediated - Auto-Verified**. 
 
 ### How It Works 
 
-
-Administrators can define requirements for vulnerability remediation based on any vulnerability rule, severity, application(s) and route which should comply. Contrast then marks any vulnerabilities that are in violation or Remediated - Auto-Verified based on this policy with a notification in the interface. Administrators are also notified of violations in the product and by email.
+Administrators can define requirements for vulnerability remediation based on any vulnerability rule, severity, application(s) and route which should comply. Contrast then marks any vulnerabilities that are in violation or **Remediated - Auto-Verified** based on this policy with a notification in the interface. Administrators are also notified of violations in the product and by email.
 
 ### Set Up Policies
 
-Go to the **User menu > Policy Management > Vulnerability Management tab** to create new policies and view existing ones in the tabbed grid. Auto-Verification policies will automatically change the status of vulnerability to Remediated - Auto-Verified. Violation policies will mark a vulnerability as being in violation of a policy. Either can be created to be triggered based on time or route.
+Go to the **User menu > Policy Management > Vulnerability Management tab** to create new policies and view existing ones in the tabbed grid. Auto-Verification policies will automatically change the status of vulnerability to **Remediated - Auto-Verified**. Violation policies will mark a vulnerability as being in violation of a policy. Either can be created to be triggered based on time or route.
 
 <a href="assets/images/Remediation-policy.png" rel="lightbox" title="Remediation Policy grid"><img class="thumbnail" src="assets/images/Remediation-policy.png"/></a>
 
@@ -64,4 +63,4 @@ Click the name of an existing policy in the grid to see its detail view and upda
 
 If a Violation policy has been triggered, Contrast adds a warning note to the Vulnerabilities thermometer in the dashboard and flags the associated vulnerabilities in the Vulnerabilities grid. Hover over the warning icon for each vulnerability in the grid, or go to the vulnerability details page for more information about the violation.
 
-If an Auto-Verification policy has been triggered, its status is updated to Remediated - Auto-verified in the Vulnerabilities grids. Hover over the status text, or go the auto-generated comment in the vulnerability's **Discussion** tab for more information about the applicable policy. 
+If an Auto-Verification policy has been triggered, its status is updated to **Remediated - Auto-verified** in the Vulnerabilities grids. Hover over the status text, or go the auto-generated comment in the vulnerability's **Discussion** tab for more information about the applicable policy. 

--- a/content/admin/policy_mgmt/VulnerabilityManagement.md
+++ b/content/admin/policy_mgmt/VulnerabilityManagement.md
@@ -1,0 +1,67 @@
+<!--
+title: "Vulnerability Management"
+description: "Overview of vulnerability management"
+tags: "Admin vulnerability policy management"
+-->
+
+> **Note:** This Vulnerability Management page consolidates the information regarding the Vulnerability Behavior section, which was previously included as part of the Applications Settings page. Additionally, the Remediation Policy page no longer exists and has been replaced by this page.
+
+Control how remediation happens. Define if vulnerabilities of a certain severity require approval to have their statuses change, or if you’d rather Contrast close them automatically for you. Go to the **User menu > Policy Management > Vulnerability Management** to get started.
+
+## Vulnerability Behavior 
+
+Check the box to **Require administrative approval when closing vulnerabilities** in your organization. In the fields below, choose the statuses and severities of vulnerabilities that should automatically go into a Pending state when a user moves to close them. When a user requests to close any qualifying vulnerabilities, Contrast will [notify](admin-orgsettings.html#org-notify) you that your review is needed.
+
+<a href="assets/images/Default-vuln-behavior.png" rel="lightbox" title="Define Vulnerability Behavior"><img class="thumbnail" src="assets/images/Default-vuln-behavior.png"/></a>
+
+> **Note:** To qualify for administrative approval, both a status and severity that you select in this configuration must apply to the vulnerability being closed. 
+
+Each vulnerability status will remain pending until you submit your review of the closure. If you deny the closure of a vulnerability, you must provide a reason for denial. Once confirmed, your feedback appears in the vulnerability's **Discussion** tab. If you disable the feature, any pending closures are automatically approved. 
+
+> **Note:** While in a Pending state, the vulnerability's previous status still applies for the purpose of organizational reports and statistics. 
+
+See [Manage Vulnerabilities](user-vulns.html#manage-vuln) for more information about Pending states and workflows.
+
+## Vulnerability Policy
+
+Create policies for vulnerabilities in your organization, and Contrast will clean up your view of security risks. As Contrast assesses your applications, it can either flag vulnerabilities that are in violation of the policy or automatically mark them Remediated - Auto-Verified. 
+
+### How It Works 
+
+
+Administrators can define requirements for vulnerability remediation based on any vulnerability rule, severity, application(s) and route which should comply. Contrast then marks any vulnerabilities that are in violation or Remediated - Auto-Verified based on this policy with a notification in the interface. Administrators are also notified of violations in the product and by email.
+
+### Set Up Policies
+
+Go to the **User menu > Policy Management > Vulnerability Management tab** to create new policies and view existing ones in the tabbed grid. Auto-Verification policies will automatically change the status of vulnerability to Remediated - Auto-Verified. Violation policies will mark a vulnerability as being in violation of a policy. Either can be created to be triggered based on time or route.
+
+<a href="assets/images/Remediation-policy.png" rel="lightbox" title="Remediation Policy grid"><img class="thumbnail" src="assets/images/Remediation-policy.png"/></a>
+
+### Add Policies 
+
+To create a new policy, select the grid tab for the type of policy desired and click the **Add Policy** button. In the **Add Auto-Verification Policy** form, define a **Name** for the policy, and click in the multiselect fields to choose the **Vulnerability Rules**, **Applications**, and **Environments** to which Contrast should apply the policy. You can add multiple vulnerabilities by Severity or select individual rules. You can also add multiple applications by Importance or select individual names. 
+
+<a href="assets/images/Add-remediation-policy.png" rel="lightbox" title="Add Remediation Policy"><img class="thumbnail" src="assets/images/Add-remediation-policy.png"/></a>
+
+### Triggers
+
+In the **Triggers** section, use the checkboxes to select the time-based and/or route-based trigger. If a time-based trigger is selected, also input the number of days after which the trigger should fire.
+
+> **Note:** When using a policy with a route-based trigger, it is recommended to also use define a time-based trigger to account for those vulnerabilities which have been remediated in such a way that cannot be associated back to the original finding in Contrast. Typically, these cases only arise when the code was deleted, and therefore cannot be re-exercised, or redefined such that it occurs on a different route.
+
+If multiple policies affect the same vulnerability, the following rules determine Contrast's course of action:
+
+* Between two time-based triggers, the action with the closest deadline applies first. For example, if a violation deadline applies first, the vulnerability is flagged and then auto-verified when the later deadline applies. 
+* Auto-verification policies take precedence over violation policies. For example, if an auto-remediation deadline applies first, the vulnerability is closed and never flagged. 
+
+> **Note:** If Contrast rediscovers a legitimate vulnerability that was auto-remediated, Contrast will [reopen the vulnerability](user-vulns.html#analyze) as usual. 
+
+### Edit Policies 
+
+Click the name of an existing policy in the grid to see its detail view and update it. Click the trashcan icon in the grid to permanently delete the policy. Once deleted, Contrast won't notify you of vulnerabilities that were within the scope of this policy. You can also use the toggles in the grid to enable or disable individual policies, if you’d like to re-use the policy again later. 
+
+## Policy Violations and Auto-Verifications 
+
+If a Violation policy has been triggered, Contrast adds a warning note to the Vulnerabilities thermometer in the dashboard and flags the associated vulnerabilities in the Vulnerabilities grid. Hover over the warning icon for each vulnerability in the grid, or go to the vulnerability details page for more information about the violation.
+
+If an Auto-Verification policy has been triggered, its status is updated to Remediated - Auto-verified in the Vulnerabilities grids. Hover over the status text, or go the auto-generated comment in the vulnerability's **Discussion** tab for more information about the applicable policy. 

--- a/content/admin/policy_mgmt/VulnerabilityManagement.md
+++ b/content/admin/policy_mgmt/VulnerabilityManagement.md
@@ -46,7 +46,7 @@ To create a new policy, select the grid tab for the type of policy desired and c
 
 In the **Triggers** section, use the checkboxes to select the time-based and/or route-based trigger. If a time-based trigger is selected, also input the number of days after which the trigger should fire.
 
-Currently for route based auto-verification to work, session metadata needs to be provided when the agent is launched. For example, `branchName=feature/some-new-thing,committer=Jane,repository=Contrast-Java`. See https://docs.contrastsecurity.com/user-vulnerableapps.html#session for more information.
+Currently for route based auto-verification to work, [session metadata](user-vulnerableapps.html#session) needs to be provided when the agent is launched. For example, `branchName=feature/some-new-thing,committer=Jane,repository=Contrast-Java`.
 
 > **Note:** When using a policy with a route-based trigger, it is recommended to also use define a time-based trigger to account for those vulnerabilities which have been remediated in such a way that cannot be associated back to the original finding in Contrast. Typically, these cases only arise when the code was deleted, and therefore cannot be re-exercised, or redefined such that it occurs on a different route.
 

--- a/content/admin/policy_mgmt/VulnerabilityManagement.md
+++ b/content/admin/policy_mgmt/VulnerabilityManagement.md
@@ -65,4 +65,4 @@ Click the name of an existing policy in the grid to see its detail view and upda
 
 If a Violation policy has been triggered, Contrast adds a warning note to the Vulnerabilities thermometer in the dashboard and flags the associated vulnerabilities in the Vulnerabilities grid. Hover over the warning icon for each vulnerability in the grid, or go to the vulnerability details page for more information about the violation.
 
-If an Auto-Verification policy has been triggered, its status is updated to **Remediated - Auto-verified** in the Vulnerabilities grids. Hover over the status text, or go the auto-generated comment in the vulnerability's **Discussion** tab for more information about the applicable policy. 
+If an Auto-Verification policy has been triggered, its status is updated to **Remediated - Auto-Verified** in the Vulnerabilities grids. Hover over the status text, or go the auto-generated comment in the vulnerability's **Discussion** tab for more information about the applicable policy. 

--- a/content/admin/policy_mgmt/VulnerabilityManagement.md
+++ b/content/admin/policy_mgmt/VulnerabilityManagement.md
@@ -46,7 +46,7 @@ To create a new policy, select the grid tab for the type of policy desired and c
 
 In the **Triggers** section, use the checkboxes to select the time-based and/or route-based trigger. If a time-based trigger is selected, also input the number of days after which the trigger should fire.
 
->**Note:** Note: Currently for route based auto-verification to work, session metadata needs to be provided when the agent is launched. For example, `branchName=feature/some-new-thing,committer=Jane,repository=Contrast-Java`. See https://docs.contrastsecurity.com/user-vulnerableapps.html#session for more information.
+Currently for route based auto-verification to work, session metadata needs to be provided when the agent is launched. For example, `branchName=feature/some-new-thing,committer=Jane,repository=Contrast-Java`. See https://docs.contrastsecurity.com/user-vulnerableapps.html#session for more information.
 
 > **Note:** When using a policy with a route-based trigger, it is recommended to also use define a time-based trigger to account for those vulnerabilities which have been remediated in such a way that cannot be associated back to the original finding in Contrast. Typically, these cases only arise when the code was deleted, and therefore cannot be re-exercised, or redefined such that it occurs on a different route.
 


### PR DESCRIPTION
I am uploading the draft of the new Vulnerability Management page. This page replaces https://docs.contrastsecurity.com/admin-policymgmt.html#remediate and includes the Vuln Behavior section from https://docs.contrastsecurity.com/admin-orgsettings.html#app-defaults.

I pulled this draft together from the gdoc draft. I will still need to do some style editing. Otherwise, I'll need help with making sure the content is correct.