### PR TITLE
Fix semantics of Java agent release note

### DIFF
--- a/content/release/ReleaseNotes3611.md
+++ b/content/release/ReleaseNotes3611.md
@@ -43,7 +43,7 @@ tags: "3.6.11 December Release Notes"
 ### Java Agent Summary
 
 Java agent improved accuracy and user experience:
-* Configured an agent to log in to a console stream no longer produces an additional log file. 
+* Configuring an agent to log to a console stream no longer produces an additional log file.
 * Assessed data flow accuracy improved for Java 11 applications.  
 * Route Coverage for Struts 2 applications is now supported. 
 

--- a/content/release/ReleaseNotes3611.md
+++ b/content/release/ReleaseNotes3611.md
@@ -44,7 +44,7 @@ tags: "3.6.11 December Release Notes"
 
 Java agent improved accuracy and user experience:
 * Configuring an agent to log to a console stream no longer produces an additional log file.
-* Assessed data flow accuracy improved for Java 11 applications.  
+* Assess data flow accuracy improved for Java 11 applications.  
 * Route Coverage for Struts 2 applications is now supported. 
 
 ### Node.js Agent Summary 


### PR DESCRIPTION
Agents do not "log in to" a console stream, they "log to" (or "emit log events to") a console stream