### PR TITLE
Updated the test bench link in node supported technologies

### DIFF
--- a/content/installation/node/NodeSupportedTechnologies.md
+++ b/content/installation/node/NodeSupportedTechnologies.md
@@ -17,6 +17,7 @@ Contrast supports Node.js Long-Term Support (LTS) versions in *Active LTS* and *
 * [Koa](https://koajs.com/) version 2.7
 * [Sails](http://sailsjs.org/) version 0.12
 * [Kraken](http://krakenjs.com/) version 2.2.0
+* [Loopback](https://loopback.io/) version 3.x
 
 While the agent can still run on web frameworks that aren't officially supported, Contrast may produce less-specific findings than it would for supported frameworks. Instead of reporting that a vulnerability occurs in your application code, Contrast may need to report it within the framework code where it interfaces directly with Node.js's built-in [http](https://nodejs.org/api/http.html) module.
 
@@ -39,16 +40,10 @@ The agent runs in the Node.js application layer. As a result, it works on **the 
 
 ## Testing Environments
 
-When changes are made, Contrast runs a battery of automated tests to ensure that it detects findings in supported technologies across all supported versions of Node. This includes tests that exercise the agent against the following Contrast applications:
+When changes are made, Contrast runs a battery of automated tests to ensure that it detects findings in supported technologies across all supported versions of Node. This includes tests that exercise the agent with all of our supported frameworks:
+* [Node Test Benches](https://github.com/Contrast-Security-oss/nodetestbenches)
 
-* [Express Test Bench](https://github.com/Contrast-Security-OSS/NodeTestBench)
-* [Koa Test Bench](https://github.com/contrast-security-oss/KoaTestBench)
-* [hapi 16 Test Bench](https://github.com/Contrast-Security-OSS/Hapi16TestBench)
-* [hapi 17 Test Bench](https://github.com/Contrast-Security-OSS/HapiTestBench/tree/hapi17)
-* [hapi 18 Test Bench](https://github.com/Contrast-Security-OSS/HapiTestBench/tree/hapi18)
-* [Kraken Test Bench](https://github.com/contrast-security-oss/KrakenTestBench)
-
-Each of these applications is updated as Contrast adds more third-party library support to the agent. If you want to add test cases, let Contrast know by clicking on the link of your chosen application and submitting a pull request.
+Each framework within the monorepo is updated as Contrast adds more third-party library support to the agent.  If you want to add test cases, this [README](https://github.com/Contrast-Security-OSS/NodeTestBenches/tree/master/test-bench-utils/README.md) explains how to contribute.
 
 ## Additional Technology
 

--- a/content/installation/node/NodeSupportedTechnologies.md
+++ b/content/installation/node/NodeSupportedTechnologies.md
@@ -43,7 +43,7 @@ The agent runs in the Node.js application layer. As a result, it works on **the 
 When changes are made, Contrast runs a battery of automated tests to ensure that it detects findings in supported technologies across all supported versions of Node. This includes tests that exercise the agent with all of our supported frameworks:
 * [Node Test Benches](https://github.com/Contrast-Security-oss/nodetestbenches)
 
-Each framework within the monorepo is updated as Contrast adds more third-party library support to the agent.  If you want to add test cases, this [README](https://github.com/Contrast-Security-OSS/NodeTestBenches/tree/master/test-bench-utils/README.md) explains how to contribute.
+Each framework within the monorepo is updated as Contrast adds more third-party library support to the agent.
 
 ## Additional Technology
 


### PR DESCRIPTION
We moved where our test bench apps live, updated the link. I also added the line item that we support loopback 3