### PR TITLE
Remove beta language about assess from Python docs

### DIFF
--- a/content/installation/python/PythonConfig.md
+++ b/content/installation/python/PythonConfig.md
@@ -149,7 +149,7 @@ Use the properties in this section to override Protect features.
 
 ### Contrast Assess properties
 
-Use the properties in this section to override Assess features (beta).
+Use the properties in this section to override Assess features.
 
 * **assess**:
   * **enable**: Set to `true` to enable or `false` to disable. Default behavior is delegated to Contrast UI. Note that `protect` and `assess` cannot be enabled at the same time.

--- a/content/installation/python/PythonOverview.md
+++ b/content/installation/python/PythonOverview.md
@@ -6,9 +6,8 @@ tags: "installation python agent overview"
 
 The Contrast Python agent provides runtime protection of Django, Flask and Pyramid web applications.
 
-Version 2.3.0 of the agent introduces beta Assess functionality. This provides the ability to find vulnerabilities in applications before they can be exploited.
-
->**Note:** The beta Assess feature can be licensed in **alpha** and **eval** instances of the Contrast UI.
+Starting with Python agent version 2.8.0, you can find application vulnerabilities with
+Assess before they can be exploited.
 
 ## About Python 
 

--- a/content/installation/python/PythonSupportedTechnologies.md
+++ b/content/installation/python/PythonSupportedTechnologies.md
@@ -8,11 +8,10 @@ The Python agent supports Python versions 2.7 and 3.5 to 3.8. Framework support 
 
 * Django: 1.10+ and 2.0+ <br> (Django 2 is available for Python 3 only.)
 * Flask: 0.10 - 0.12 and 1.0+
-* Pyramid: 1.9 (Beta)
+* Pyramid: 1.9
 * Pylons: 1.0+
 
->**Notes:** 
- * Only Django is officially supported for the beta release of **Assess** capability.
+>**Note:**
 * The Python agent is meant to be WSGI compatible. It may be compatible to other WSGI applications as long as the guidelines are followed.
 
 


### PR DESCRIPTION
As of version 2.8.0 of the agent, Assess is no longer in Beta, so we need to remove this language from the docs.