### PR TITLE
DOCS-118 Ruby 2.4 EOL

### DIFF
--- a/content/installation/ruby/RubySupportedTechnologies.md
+++ b/content/installation/ruby/RubySupportedTechnologies.md
@@ -20,6 +20,16 @@ As the agent has *C* dependencies, it may need to be installed with the `--platf
 
 Contrast supports Ruby Long-Term Support (LTS) versions in **normal maintenance** and **security maintenance** status. Contrast shifts its support for Ruby versions as the working group shifts its LTS windows. See the [Ruby Maintenance Branches schedule](https://www.ruby-lang.org/en/downloads/branches/) for specific release dates.
 
+### Supported
+
+* 2.7.X: First supported agent was 3.8.0
+* 2.6.X: First supported agent was 2.3.0
+* 2.5.X: First supported agent was 2.0.0
+
+### Deprecated
+
+* 2.4.X: Last supported agent was 3.9.1
+
 ## Web servers
 
 * [Passenger](https://www.phusionpassenger.com/) 5.X-6.X


### PR DESCRIPTION
Add supported and deprecated sections in an effort to clearly delineate which versions of Ruby are supported. This is mirrored and enforced by our deploys to RubyGems.

:pushpin: add documentation for first supported version of currently supported Ruby
:pushpin: add documentation for last supported version of deprecated Ruby