### PR TITLE
Updated way to install node agent

### DIFF
--- a/content/installation/node/NodeConfig.md
+++ b/content/installation/node/NodeConfig.md
@@ -4,7 +4,7 @@ description: "Configuring the Node.js Agent"
 tags: "installation NodeJS agent configuration"
 -->
 
-You may use configuration options to alter Contrast's behavior. They can all be appended to your startup command (e.g., `npm run contrast -- --agent.logger.stdout false` or `node-contrast server.js --agent.logger.stdout false`). They can also be set via environment variables of the form `SETTING__NAME` (e.g., `--agent.logger.stdout false` becomes `AGENT__LOGGER__STDOUT=false`). With the exception of `--configFile`, they can all be added to your *contrast_security.yaml* file as well.
+You may use configuration options to alter Contrast's behavior. They can all be appended to your startup command (e.g., `npm run contrast -- --agent.logger.stdout false` or `node -r @contrast/agent server.js --agent.logger.stdout false`). They can also be set via environment variables of the form `SETTING__NAME` (e.g., `--agent.logger.stdout false` becomes `AGENT__LOGGER__STDOUT=false`). With the exception of `--configFile`, they can all be added to your *contrast_security.yaml* file as well.
 
 ## General Configuration Options
 
@@ -112,9 +112,7 @@ From the Node.js documentation, you can see scripts are executed in the followin
 node [options] [V8 options] [script.js] [--] [arguments];
 ```
 
-The Contrast agent is a Node.js wrapper (runner) that invokes `node` to start the application. The agent doesn't pass any flags to the underlying Node.js executable, or provide the ability to do so with agent configuration options. To pass CLI flags to Node.js, you must invoke `node` explicitly with the agent as the `script` argument, followed by the name of the application's entry point file and any configuration flags, as outlined above.
-
-When the agent is installed, a symlink is created, `<app-dir>/node_modules/.bin/node-contrast`, which points to the file `<app-dir>/node_modules/node_contrast/cli.js`. You can use either of these as the `script` argument when starting the application this way.
+The agent doesn't pass any flags to the underlying Node.js executable, or provide the ability to do so with agent configuration options. To pass CLI flags to Node.js, you must invoke `node` explicitly with the agent as the `script` argument, followed by the name of the application's entry point file and any configuration flags, as outlined above.
 
 > **Example:** <br> Without the Contrast agent, you start your application using the following command:
 >
@@ -125,9 +123,5 @@ When the agent is installed, a symlink is created, `<app-dir>/node_modules/.bin/
 > To run the application with the same Node.js flags and the Contrast agent, you could use either of the following commands:
 >
 > ```shell
-> node --title=MyWebsite --stack-trace-limit=25 ./node_modules/.bin/node-contrast ./index.js -- --env development
-> ```
->
-> ```shell
-> node --title=MyWebsite --stack-trace-limit=25 ./node_modules/node_contrast/cli.js ./index.js -- --env development
+> node -r @contrast/agent ./index.js --title=MyWebsite --stack-trace-limit=25 -- --env development
 > ```

--- a/content/installation/node/NodeConfig.md
+++ b/content/installation/node/NodeConfig.md
@@ -49,7 +49,6 @@ Parameter                                      | Environment Variable           
 --agent.service.port                           | AGENT\_\_SERVICE\_PORT                          | Set the the port of the Contrast service to which the Contrast agent should report. Example: `30555`
 --agent.service.logger.path                    | AGENT\_\_SERVICE\_\_LOGGER\_PATH                | Set the location to which the Contrast service saves log output. If no log file exists at this location, the service creates one. Example: */opt/Contrast/contrast_service.log* will create a log in the */opt/Contrast* directory.
 --agent.service.logger.level                   | AGENT\_\_SERVICE\_\_LOGGER\_LEVEL               | Set the the log output level. Value options are `ERROR`, `WARN`, `INFO`, and `DEBUG`.
---application.args <args>                      | APPLICATION\_\_ARGS                             | String containing `args` to pass verbatim to the application. (E.g., `--application.args "-A -S -D -F foo bar"`.)
 --application.code <code>                      | APPLICATION\_\_CODE                             | Add the application code this application should use in the Contrast UI.
 --application.group <tags>                     | APPLICATION\_\_GROUP                            | How to report the application's group for auto-grouping.
 --application.name <name>                      | APPLICATION\_\_NAME                             | Override the reported application name. Default is `package.json:name`.
@@ -99,7 +98,7 @@ By default, the agent logs to *<app_root>/node-contrast.log*. For performance re
 
 ## Application Arguments
 
-To pass configuration options to the application being run with Contrast, use the `--application.args` flag, or append `--` to the run command, followed by the arguments for the application.
+To pass configuration options to the application being run with Contrast, append `--` to the run command, followed by the arguments for the application.
 
 > **Example:** `npm run contrast -- --agent.logger.level debug -- --appArg0 foo --appArg1 bar` will pass `appArg0 foo` and `appArg1 bar` directly to the application.
 

--- a/content/installation/node/NodeConfig.md
+++ b/content/installation/node/NodeConfig.md
@@ -123,5 +123,5 @@ The agent doesn't pass any flags to the underlying Node.js executable, or provid
 > To run the application with the same Node.js flags and the Contrast agent, you could use either of the following commands:
 >
 > ```shell
-> node -r @contrast/agent ./index.js --title=MyWebsite --stack-trace-limit=25 -- --env development
+> node --title=MyWebsite --stack-trace-limit=25 -r @contrast/agent ./index.js -- --env development
 > ```

--- a/content/installation/node/NodeInstall.md
+++ b/content/installation/node/NodeInstall.md
@@ -6,23 +6,19 @@ tags: "NodeJS agent installation"
 
 
 ## Installation
-
-After downloading from your account, install the agent from your application's root directory:
-
 ``` sh
-npm install node-contrast-#.#.#.tgz --no-save
+npm install @contrast/agent
 ```
-This command will add the agent to your *node_modules* folder without creating an entry in the dependencies list of your *package.json* file.
 
 If you use **yarn**, use an alternate command to install the agent:
 
 ``` sh
-yarn add file:node-contrast-#.#.#.tgz
+yarn add @contrast/agent
 ```
 
 ## Setup
 
-When you download the Node agent, you will also be directed to download a configuration file. By default, the agent looks for this configuration file in your application's root directory and expects the file to be called *contrast_security.yaml*.
+You can download a configuration file from your account. By default, the agent looks for this configuration file in your application's root directory and expects the file to be called *contrast_security.yaml*.
 
 The minimum required *contrast_security.yaml* setup should look something like this:
 
@@ -51,7 +47,7 @@ First, add the following script to your application's *package.json*:
 
 ``` javascript
 "scripts": {
-	"contrast": "node-contrast <app-main>.js",
+	"contrast": "node -r @contrast/agent <app-main>.js",
 	"start": ...,
 	"test": ...
 }

--- a/content/installation/node/NodeInstallBluemix.md
+++ b/content/installation/node/NodeInstallBluemix.md
@@ -8,13 +8,11 @@ Use the Contrast agent to instrument Node applications deployed on IBM Bluemix. 
 
 ## Download
 
-* Download the Node.js agent from Contrast. 
-
 * Download the *contrast_security.yaml* file from Contrast.
 
 ## Setup
 
-* In the *contrast_security.yaml* file, you can configure the name of the server to which this application will report. (Contrast recommends that you complete this step to avoid creating duplicate servers in the application.) To configure the server name as "BluemixNodeServer" in Contrast, add `server.name: BluemixNodeServer`. 
+* In the *contrast_security.yaml* file, you can configure the name of the server to which this application will report. (Contrast recommends that you complete this step to avoid creating duplicate servers in the application.) To configure the server name as "BluemixNodeServer" in Contrast, add `server.name: BluemixNodeServer`.
 
 > **Example:**
 ```yaml
@@ -27,19 +25,18 @@ Use the Contrast agent to instrument Node applications deployed on IBM Bluemix. 
    name: BluemixNodeServer
 ```
 
-<br> 
+<br>
 
-> **Note:** To find other options for customizing the Node agent, go to the [Configuration article](installation-node.html#node-config). 
+> **Note:** To find other options for customizing the Node agent, go to the [Configuration article](installation-node.html#node-config).
 
 * Create a folder named *contrast* in your application’s root directory.
 
-* Move the *node-contrast-<version>.tgz* and the *contrast_security.yaml* files into the *contrast* folder.
+* Move the *contrast_security.yaml* files into the *contrast* folder.
 
 * In the application’s *package.json* file, create a new script. For a startup script named *index.js*, add the following line:
 
 ```
-"bluemix-with-contrast": "npm install /home/vcap/app/contrast/node-contrast-
-x.y.z.tgz && node-contrast index.js -c /home/vcap/app/contrast/contrast_security.yaml",
+"bluemix-with-contrast": "npm install @contrast/agent && node -r @contrast/agent index.js -c /home/vcap/app/contrast/contrast_security.yaml",
 ```
 
 ## Run the Agent
@@ -50,8 +47,7 @@ x.y.z.tgz && node-contrast index.js -c /home/vcap/app/contrast/contrast_security
 "start":"npm run bluemix-with-contrast"
 Now the scripts section of the package.json should look like the following:
 "scripts": {
-"bluemix-with-contrast": "npm install /home/vcap/app/contrast/node-contrast-
-x.y.z.tgz && node-contrast index.js -c /home/vcap/app/contrast/contrast_security.yaml",
+"bluemix-with-contrast": "npm install @contrast/agent && node -r @contrast/agent index.js -c /home/vcap/app/contrast/contrast_security.yaml",
 "start":"npm run bluemix-with-contrast”
 },
 ```

--- a/content/installation/node/NodeOverview.md
+++ b/content/installation/node/NodeOverview.md
@@ -4,19 +4,19 @@ description: "About the Node.js agent"
 tags: "installation NodeJS agent overview"
 -->
 
-The Contrast Node agent analyzes the behavior of Node.js web applications using established techniques, such as source-to-source compilation, to add Contrast sensors to an application prior to execution. Just as tools such as Istanbul and CoffeeScript use this technique to weave new features into JavaScript, Contrast uses it to help you keep your applications secure.
+The Contrast Node.js agent analyzes the behavior of Node.js web applications using established techniques, such as source-to-source compilation, to add Contrast sensors to an application prior to execution. Just as tools such as Istanbul and CoffeeScript use this technique to weave new features into JavaScript, Contrast uses it to help you keep your applications secure.
 
 ## About the Agent
 
 There are two primary source code transformations that the Contrast Node agent employs to monitor the behavior of your application:
 
-**Function hooks** take over the execution of a given function like, `child_process.exec`, to collect data about its arguments and its return value, and send this data to the parts of the agent responsible for analysis. As a result, the agent enables certain functions to be self reporting. 
+**Function hooks** take over the execution of a given function like, `child_process.exec`, to collect data about its arguments and its return value, and send this data to the parts of the agent responsible for analysis. As a result, the agent enables certain functions to be self reporting.
 
 **AST transformation** is the process by which the agent creates an [abstract syntax tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) of a body of code, manipulates the tree and then creates new source code based on this syntax tree. The agent goes through this process to handle scenarios in which function hooks won't work. For example, rewrites allow Contrast to add [operator overloading](https://en.wikipedia.org/wiki/Operator_overloading) to JavaScript so that it can properly track the flow of untrusted data.
 
-## Use the Agent 
+## Use the Agent
 
-To start analyzing an application, download the Node.js agent and create a configuration file. The process is outlined in the [Node Agent Installation](installation-nodeinstall.html) article. Just like you would run your application with `node <app-main.js>`, the Contrast Node agent allows you to run your application with `node ./node_modules/node_contrast <app-main>.js`.
+To start analyzing an application, download the Node.js agent and create a configuration file. The process is outlined in the [Node Agent Installation](installation-nodeinstall.html) article.
 
 
 

--- a/content/installation/node/NodeSupportedTechnologies.md
+++ b/content/installation/node/NodeSupportedTechnologies.md
@@ -13,11 +13,11 @@ Contrast supports Node.js Long-Term Support (LTS) versions in *Active LTS* and *
 ## Web Framework Support
 
 * [Express](http://expressjs.com) version 4
-* [hapi](https://www.npmjs.com/package/hapi) versions 16-18
+* [hapi](https://www.npmjs.com/package/hapi) versions 16-19
 * [Koa](https://koajs.com/) version 2.7
-* [Sails](http://sailsjs.org/) version 0.12
 * [Kraken](http://krakenjs.com/) version 2.2.0
 * [Loopback](https://loopback.io/) version 3.x
+* [Fastify](https://www.fastify.io/) version 2.x
 
 While the agent can still run on web frameworks that aren't officially supported, Contrast may produce less-specific findings than it would for supported frameworks. Instead of reporting that a vulnerability occurs in your application code, Contrast may need to report it within the framework code where it interfaces directly with Node.js's built-in [http](https://nodejs.org/api/http.html) module.
 

--- a/content/installation/node/NodeTranspilers.md
+++ b/content/installation/node/NodeTranspilers.md
@@ -19,7 +19,7 @@ Please refer to the following example script setup for running Contrast with a C
 scripts: {
     "test": "...",
     "start": "...",
-    "contrast": "node-contrast /path/to/coffee/transpiler --application.args '/path/to/app/entrypoint.cofee'"
+    "contrast": "node -r @contrast/agent /path/to/coffee/transpiler -- '/path/to/app/entrypoint.cofee'"
 }
 ```
 
@@ -30,7 +30,7 @@ Some languages, like [TypeScript](http://www.typescriptlang.org/), require you t
 scripts: {
     "test": "...",
     "start": "...",
-    "contrast": "node-contrast /path/to/compiled/entrypoint.js"
+    "contrast": "node -r @contrast/agent /path/to/compiled/entrypoint.js"
 }
 ```
 

--- a/content/installation/node/NodeTranspilers.md
+++ b/content/installation/node/NodeTranspilers.md
@@ -4,26 +4,10 @@ description: "Notes on Contrast compatibility with languages like CoffeeScript o
 tags: "node agent compatibility coffee coffeescript typescript babel"
 -->
 
-Contrast supports applications written in languages that compile to JavaScript, such as [CoffeeScript](http://coffeescript.org/) and [TypeScript](http://www.typescriptlang.org/). While Contrast only instruments JavaScript, you can tell Contrast how to get to the compiled code; whether the JavaScript is precompiled or compiled at runtime determines your method.
+Contrast supports applications written in languages that compile to JavaScript, such as [CoffeeScript](http://coffeescript.org/) and [TypeScript](http://www.typescriptlang.org/). While Contrast only instruments JavaScript, you can tell Contrast how to get to the compiled code.
 
 > **Note:** Although Contrast functions with languages that compile to JavaScript, the source may not correspond directly with the resulting JavaScript. As a result, reported metadata - such as vulnerability line-of-code and filename - references the compiled result, not the original source.
 
-## Runtime Compilers
-Languages like [CoffeeScript](http://coffeescript.org/) run via a command line utility, which acts as a *runner* and compiles your application to JavaScript at runtime. It's possible to have Contrast's Node.js agent act as a runner for the runtime transpiler, which acts as a runner for your application.
-
-To set up Contrast as a runner, you must provide the entrypoint to the transpiler instead of providing the entrypoint to your application as an argument. (You're essentially telling Contrast that your application is the transpiler.) Next, you must use the ```--appArgs``` setting to tell Contrast to pass this argument along.
-
-Please refer to the following example script setup for running Contrast with a CoffeeScript application:
-
-```javascript
-scripts: {
-    "test": "...",
-    "start": "...",
-    "contrast": "node -r @contrast/agent /path/to/coffee/transpiler -- '/path/to/app/entrypoint.cofee'"
-}
-```
-
-## Precompiled
 Some languages, like [TypeScript](http://www.typescriptlang.org/), require you to precompile your code before runtime. In these cases, Contrast must simply point to the *compiled* entrypoint for your application:
 
 ```javascript


### PR DESCRIPTION
This PR updates how to install agent to only highlight via npm.  We were getting a lot of support questions and I felt like this was needed before the larger node agent docs rewrite.  I also noticed our supported frameworks was out of date